### PR TITLE
Add index to make this package work with webpack

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,1 @@
+export { default } from './MultiSelect.svelte'


### PR DESCRIPTION
Im using webpack5 and when I install this package, I received the error like the image below
![image](https://user-images.githubusercontent.com/20919532/136926704-2daef887-21e6-43bf-a878-71e042c58e11.png)


In order to fix this problem, I must add an index.js file into `lib` folder