### PR TITLE
Fix MultiSelect `localStorage` binding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,9 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Set up node v17
+      - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
           cache: yarn
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "svelte-check": "^2.4.6",
     "svelte-github-corner": "^0.1.0",
     "svelte-preprocess": "^4.10.4",
-    "svelte-toc": "^0.2.8",
+    "svelte-toc": "^0.2.9",
     "svelte2tsx": "^0.5.6",
     "tslib": "^2.3.1",
     "typescript": "^4.6.2",

--- a/readme.md
+++ b/readme.md
@@ -381,7 +381,7 @@ export default {
 }
 ```
 
-Here's a [Stackblitz example](https://stackblitz.com/fork/github/davipon/test-svelte-multiselect?initialPath=__vitest__) that also uses [`'vitest-svelte-kit'`](https://github.com/nickbreaton/vitest-svelte-kit).
+Here's a [Stackblitz example](https://stackblitz.com/fork/github/davipon/test-svelte-multiselect?initialPath=__vitest__) that also uses [`vitest-svelte-kit`](https://github.com/nickbreaton/vitest-svelte-kit).
 
 ## Want to contribute?
 

--- a/src/app.css
+++ b/src/app.css
@@ -59,9 +59,6 @@ pre {
   font-size: 9pt;
   background-color: rgba(0, 0, 0, 0.6);
 }
-a code {
-  color: white;
-}
 ul li {
   margin: 1ex 0;
 }

--- a/src/components/Examples.svelte
+++ b/src/components/Examples.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import MultiSelect, { Option, Primitive } from '../lib'
+  import MultiSelect, { Option } from '../lib'
   import Confetti from './Confetti.svelte'
   import { colors, ml_libs, languages, frontend_libs } from '../options'
   import ColorSlot from './ColorSlot.svelte'
   import LanguageSlot from './LanguageSlot.svelte'
+  import { language_store } from '../stores'
 
-  let selectedLangs: Primitive[]
   let selectedML: Option[]
   let selectedFruit: Option[]
 
@@ -31,7 +31,7 @@
 <section>
   <h3>Multi Select</h3>
 
-  <pre>bind:selectedLabels = {JSON.stringify(selectedLangs)}</pre>
+  <pre>bind:selectedLabels = {JSON.stringify($language_store.map((t) => t.label))}</pre>
 
   <label for="languages">Favorite programming languages?</label>
 
@@ -39,7 +39,7 @@
     id="languages"
     options={languages}
     {placeholder}
-    bind:selectedLabels={selectedLangs}
+    bind:selected={$language_store}
   >
     <LanguageSlot let:option {option} slot="selected" />
   </MultiSelect>

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount, tick } from 'svelte'
+  import { createEventDispatcher, tick } from 'svelte'
   import { fly } from 'svelte/transition'
   import type { Option, Primitive, ProtoOption, DispatchEvents } from './'
   import CircleSpinner from './CircleSpinner.svelte'
   import { CrossIcon, ExpandIcon, DisabledIcon } from './icons'
   import Wiggle from './Wiggle.svelte'
 
-  export let selected: Option[] = []
   export let selectedLabels: Primitive[] = []
   export let selectedValues: Primitive[] = []
   export let searchText = ``
@@ -16,6 +15,8 @@
   export let disabled = false
   export let disabledTitle = `This field is disabled`
   export let options: ProtoOption[]
+  export let selected: Option[] =
+    (options as Option[]).filter((op) => op?.preselected) ?? []
   export let input: HTMLInputElement | null = null
   export let outerDiv: HTMLDivElement | null = null
   export let placeholder: string | undefined = undefined
@@ -51,10 +52,6 @@
   }
   if (!(options?.length > 0)) console.error(`MultiSelect missing options`)
   if (!Array.isArray(selected)) console.error(`selected prop must be an array`)
-
-  onMount(() => {
-    selected = _options.filter((op) => op?.preselected) ?? []
-  })
 
   const dispatch = createEventDispatcher<DispatchEvents>()
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -32,7 +32,7 @@ export const ml_libs = [
 // prettier-ignore
 export const languages = [
   `JavaScript`, `TypeScript`, `CoffeeScript`, `Python`, `Ruby`, `C`, `C#`, `C++`, `Go`, `Swift`, `Java`, `Rust`, `Kotlin`, `Haskell`, `Scala`, `Clojure`, `Erlang`, `Elixir`, `F#`, `Dart`, `Elm`, `Julia`, `Lua`, `R`, `OCaml`, `Perl`, `PHP`
-].map(lang => ({label: lang, value: lang, preselected: [`Python`, `TypeScript`, `C`].includes(lang) }))
+]
 
 // prettier-ignore
 export const fruits = [

--- a/src/routes/__error.svelte
+++ b/src/routes/__error.svelte
@@ -19,14 +19,16 @@
 <div>
   {#if status === 404}
     <h1>{error.name} {status}: Page not found 😅</h1>
-  {:else if status >= 500}
-    <h1>{error.name} {status}</h1>
-    <p>
-      This may be our fault. If page reloading doesn't help, please raise an issue on
-      <a href="https://github.com/janosh/svelte-multiselect/issues">GitHub</a>. Thanks! 🙏
-    </p>
   {:else}
     <h1>⚠️ {error.name} {status}</h1>
+    {#if status >= 500}
+      <p>
+        Oops, our bad. If page reloading doesn't help, please raise an issue on
+        <a href="https://github.com/janosh/svelte-multiselect/issues">GitHub</a>. Thanks!
+        🙏
+      </p>
+      <br />
+    {/if}
   {/if}
   <p>
     Return to <a sveltekit:prefetch href="/">index page</a>.

--- a/src/routes/demos/persistent.svx
+++ b/src/routes/demos/persistent.svx
@@ -1,0 +1,38 @@
+<script>
+  import MultiSelect from '$lib'
+  import { languages } from '$src/options'
+  import LanguageSlot from '$src/components/LanguageSlot.svelte'
+  import { language_store } from '$src/stores'
+</script>
+
+## Page-Reload Persistent MultiSelect
+
+```svelte
+<script>
+  import { language_store } from '$src/stores'
+</script>
+
+<MultiSelect
+  id="languages"
+  options={languages}
+  placeholder="What languages do you know?"
+  bind:selected={$language_store}
+>
+  <LanguageSlot let:option {option} slot="selected" />
+</MultiSelect>
+```
+
+<br />
+
+<MultiSelect
+  id="languages"
+  options={languages}
+  placeholder="What languages do you know?"
+  bind:selected={$language_store}
+>
+  <LanguageSlot let:option {option} slot="selected" />
+</MultiSelect>
+
+<br />
+
+Test that component when bound to `localStorage` retains its `selected` state on page reload.

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store'
+import { Option } from './lib'
+
+function session_store<T>(name: string, initialValue: T) {
+  if (typeof sessionStorage !== `undefined` && sessionStorage[name]) {
+    try {
+      initialValue = JSON.parse(sessionStorage[name])
+    } catch (err) {
+      console.error(
+        `Error parsing sessionStorage[${name}]: ${err}, resetting to initial value ${initialValue}`
+      )
+      sessionStorage[name] = JSON.stringify(initialValue)
+    }
+  }
+
+  const { subscribe, set } = writable(initialValue)
+
+  return {
+    subscribe,
+    set: (val: T) => {
+      if (val !== undefined && typeof sessionStorage !== `undefined`) {
+        sessionStorage[name] = JSON.stringify(val)
+      }
+      set(val)
+    },
+  }
+}
+
+export const language_store = session_store<Option[]>(
+  `language-store`,
+  [`Python`, `TypeScript`, `C`].map((lang) => ({ label: lang, value: lang }))
+)

--- a/tests/multiselect.test.ts
+++ b/tests/multiselect.test.ts
@@ -238,4 +238,25 @@ describe(`multiselect`, async () => {
       `Nectarine Lime`
     )
   })
+
+  test.only(`retains its selected state on page reload when bound to localStorage`, async () => {
+    const page = await context.newPage()
+    await page.goto(`/demos/persistent`)
+
+    await page.locator(`input[name="languages"]`).click()
+
+    await page.locator(`text=Haskell >> nth=0`).click()
+
+    await page.locator(`input[name="languages"]`).fill(`java`)
+
+    await page.locator(`text=JavaScript`).click()
+
+    await page.reload()
+
+    await page.waitForTimeout(300)
+
+    const selected_text = await page.textContent(`.multiselect > ul.selected`)
+    expect(selected_text).toContain(`JavaScript`)
+    expect(selected_text).toContain(`Haskell`)
+  })
 })

--- a/tests/multiselect.test.ts
+++ b/tests/multiselect.test.ts
@@ -239,7 +239,7 @@ describe(`multiselect`, async () => {
     )
   })
 
-  test.only(`retains its selected state on page reload when bound to localStorage`, async () => {
+  test(`retains its selected state on page reload when bound to localStorage`, async () => {
     const page = await context.newPage()
     await page.goto(`/demos/persistent`)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,10 +1947,10 @@ svelte-preprocess@^4.0.0, svelte-preprocess@^4.10.4:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte-toc@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/svelte-toc/-/svelte-toc-0.2.8.tgz#8f4b9b6401154b4ff93bc27a8e68f1c69a3b46c7"
-  integrity sha512-69HbUosFZ3zJJfHQWSa6rEsLvLEZbotBVN7jOjhGvHUYhdulAvoZpZjY1v2206rVMHArWrXYwECDhSO+ThS9xw==
+svelte-toc@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/svelte-toc/-/svelte-toc-0.2.9.tgz#7fc857a3cca8d1a31fd28a7636d03635cc1d8ae3"
+  integrity sha512-08aOB3skVxcw4y1A1vy5u7+/QZ8KfudMXjuxQp51gHh56gmWh+/eXGo8fNE/og/JQ2qqvRK7JMdCG8nF3hRxgQ==
 
 svelte2tsx@^0.5.6:
   version "0.5.6"


### PR DESCRIPTION
Used to overwrite previous value on page reload when bound to `localStorage`. Now only applying `preselected` state on initial component mount.