### PR TITLE
Allow empty Multiselect

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -371,64 +371,69 @@
     {/if}
   {/if}
 
-  <ul class:hidden={!showOptions} class="options {ulOptionsClass}">
-    {#each matchingOptions as option, idx}
-      {@const {
-        label,
-        disabled = null,
-        title = null,
-        selectedTitle = null,
-        disabledTitle = defaultDisabledTitle,
-      } = option instanceof Object ? option : { label: option }}
-      {@const active = activeOption && get_label(activeOption) === label}
-      <li
-        on:mousedown|stopPropagation
-        on:mouseup|stopPropagation={() => {
-          if (!disabled) is_selected(label) ? remove(label) : add(label)
-        }}
-        title={disabled ? disabledTitle : (is_selected(label) && selectedTitle) || title}
-        class:selected={is_selected(label)}
-        class:active
-        class:disabled
-        class="{liOptionClass} {active ? liActiveOptionClass : ``}"
-        on:mouseover={() => {
-          if (!disabled) activeOption = option
-        }}
-        on:focus={() => {
-          if (!disabled) activeOption = option
-        }}
-        on:mouseout={() => (activeOption = null)}
-        on:blur={() => (activeOption = null)}
-        aria-selected="false"
-      >
-        <slot name="option" {option} {idx}>
-          {#if parseLabelsAsHtml}
-            {@html get_label(option)}
-          {:else}
-            {get_label(option)}
-          {/if}
-        </slot>
-      </li>
-    {:else}
-      {#if allowUserOptions && searchText}
+  <!-- only render options dropdown if options or searchText is not empty needed to avoid briefly flashing empty dropdown -->
+  {#if searchText || options?.length > 0}
+    <ul class:hidden={!showOptions} class="options {ulOptionsClass}">
+      {#each matchingOptions as option, idx}
+        {@const {
+          label,
+          disabled = null,
+          title = null,
+          selectedTitle = null,
+          disabledTitle = defaultDisabledTitle,
+        } = option instanceof Object ? option : { label: option }}
+        {@const active = activeOption && get_label(activeOption) === label}
         <li
           on:mousedown|stopPropagation
-          on:mouseup|stopPropagation={() => add(searchText)}
-          title={addOptionMsg}
-          class:active={activeMsg}
-          on:mouseover={() => (activeMsg = true)}
-          on:focus={() => (activeMsg = true)}
-          on:mouseout={() => (activeMsg = false)}
-          on:blur={() => (activeMsg = false)}
+          on:mouseup|stopPropagation={() => {
+            if (!disabled) is_selected(label) ? remove(label) : add(label)
+          }}
+          title={disabled
+            ? disabledTitle
+            : (is_selected(label) && selectedTitle) || title}
+          class:selected={is_selected(label)}
+          class:active
+          class:disabled
+          class="{liOptionClass} {active ? liActiveOptionClass : ``}"
+          on:mouseover={() => {
+            if (!disabled) activeOption = option
+          }}
+          on:focus={() => {
+            if (!disabled) activeOption = option
+          }}
+          on:mouseout={() => (activeOption = null)}
+          on:blur={() => (activeOption = null)}
           aria-selected="false"
         >
-          {addOptionMsg}
+          <slot name="option" {option} {idx}>
+            {#if parseLabelsAsHtml}
+              {@html get_label(option)}
+            {:else}
+              {get_label(option)}
+            {/if}
+          </slot>
         </li>
       {:else}
-        <span>{noOptionsMsg}</span>
-      {/if}
-    {/each}
-  </ul>
+        {#if allowUserOptions && searchText}
+          <li
+            on:mousedown|stopPropagation
+            on:mouseup|stopPropagation={() => add(searchText)}
+            title={addOptionMsg}
+            class:active={activeMsg}
+            on:mouseover={() => (activeMsg = true)}
+            on:focus={() => (activeMsg = true)}
+            on:mouseout={() => (activeMsg = false)}
+            on:blur={() => (activeMsg = false)}
+            aria-selected="false"
+          >
+            {addOptionMsg}
+          </li>
+        {:else}
+          <span>{noOptionsMsg}</span>
+        {/if}
+      {/each}
+    </ul>
+  {/if}
 </div>
 
 <style>

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -111,8 +111,18 @@
       ) {
         // user entered text but no options match, so if allowUserOptions=true | 'append', we create
         // a new option from the user-entered text
-        if (typeof options[0] === `string`) option = searchText
-        else option = { label: searchText, value: searchText }
+        if (typeof options[0] === `object`) {
+          // if 1st option is an object, we create new option as object to keep type homogeneity
+          option = { label: searchText, value: searchText }
+        } else {
+          if (
+            [`number`, `undefined`].includes(typeof options[0]) &&
+            !isNaN(Number(searchText))
+          ) {
+            // create new option as number if it parses to a number and 1st option is also number or missing
+            option = Number(searchText)
+          } else option = searchText // else create custom option as string
+        }
         if (allowUserOptions === `append`) options = [...options, option]
       }
       searchText = `` // reset search string on selection

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -53,7 +53,7 @@
 
   type $$Events = MultiSelectEvents // for type-safe event listening on this component
 
-  if (!(options?.length > 0)) console.error(`MultiSelect received no options`)
+  if (!(options?.length > 0) && !allowUserOptions) console.error(`MultiSelect received no options`)
   if (parseLabelsAsHtml && allowUserOptions)
     console.warn(
       `You shouldn't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -53,16 +53,25 @@
 
   type $$Events = MultiSelectEvents // for type-safe event listening on this component
 
-  if (!(options?.length > 0) && !allowUserOptions)
-    console.error(`MultiSelect received no options`)
-  if (parseLabelsAsHtml && allowUserOptions)
+  if (!(options?.length > 0)) {
+    if (allowUserOptions) {
+      options = [] // initializing as array avoids errors when component mounts
+    } else {
+      // only error for empty options if user is not allowed to create custom options
+      console.error(`MultiSelect received no options`)
+    }
+  }
+  if (parseLabelsAsHtml && allowUserOptions) {
     console.warn(
       `You shouldn't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`
     )
+  }
   if (maxSelect !== null && maxSelect < 1) {
     console.error(`maxSelect must be null or positive integer, got ${maxSelect}`)
   }
-  if (!Array.isArray(selected)) console.error(`selected prop must be an array`)
+  if (!Array.isArray(selected)) {
+    console.error(`selected prop must be an array, got ${selected}`)
+  }
 
   const dispatch = createEventDispatcher<DispatchEvents>()
   let activeMsg = false // controls active state of <li>{addOptionMsg}</li>

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -53,7 +53,8 @@
 
   type $$Events = MultiSelectEvents // for type-safe event listening on this component
 
-  if (!(options?.length > 0) && !allowUserOptions) console.error(`MultiSelect received no options`)
+  if (!(options?.length > 0) && !allowUserOptions)
+    console.error(`MultiSelect received no options`)
   if (parseLabelsAsHtml && allowUserOptions)
     console.warn(
       `You shouldn't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`

--- a/src/routes/allow-user-options.svx
+++ b/src/routes/allow-user-options.svx
@@ -6,6 +6,7 @@
   // make some options pre-selected
   let selected = '🍇 Grapes, 🍈 Melon, 🍉 Watermelon, 🍊 Tangerine'.split(', ')
   let selected_append = ['Haskell', 'TypeScript']
+  let selected_empty = []
 </script>
 
 <label for="foods">Allow Custom User Input</label>
@@ -50,4 +51,32 @@
   <LanguageSlot let:option {option} slot="selected" />
   <LanguageSlot let:option {option} slot="option" />
 </MultiSelect>
+```
+
+<br />
+<br />
+<br />
+
+<label for="languages">Start empty</label>
+
+Starting with no options and letting the user populate their selection from scratch.
+
+{#if selected_empty?.length > 0}
+  <pre><code>selected = {JSON.stringify(selected_empty)}</code></pre>
+{/if}
+
+<MultiSelect
+  id="no-default-options"
+  allowUserOptions="append"
+  bind:selected={selected_empty}
+  noOptionsMsg=""
+/>
+
+```svelte
+<MultiSelect
+  id="no-default-options"
+  allowUserOptions="append"
+  bind:selected={selected_empty}
+  noOptionsMsg=""
+/>
 ```

--- a/tests/multiselect.test.ts
+++ b/tests/multiselect.test.ts
@@ -364,6 +364,33 @@ describe(`allowUserOptions`, async () => {
     const ul_selected = await page.$(`ul.selected >> text=foobar`)
     expect(ul_selected).toBeTruthy()
   })
+
+  test(`can create custom option starting from empty options array`, async () => {
+    // and doesn't error about empty options when custom options allowed
+    const page = await context.newPage()
+    const logs: string[] = []
+    page.on(`console`, (msg) => {
+      if (msg.type() === `error`) logs.push(msg.text())
+    })
+    const selector = `input#no-default-options`
+
+    await page.goto(`/allow-user-options`)
+
+    await page.click(selector)
+
+    await page.fill(selector, `foo`)
+    await page.press(selector, `Enter`) // create custom option
+    await page.fill(selector, `42`)
+    await page.press(selector, `Enter`) // 2nd create custom option
+
+    const ul_selected = await page.$(`ul.selected >> text=42`)
+    expect(ul_selected).toBeTruthy()
+
+    const logged_err_msg = logs.some((msg) =>
+      msg.includes(`MultiSelect received no options`)
+    )
+    expect(logged_err_msg).toBe(false)
+  })
 })
 
 describe(`sortSelected`, async () => {


### PR DESCRIPTION
If user can fill their own entries using  `allowUserOptions`, avoid console error when Multiselect is rendered without options.