### PR TITLE
Fix 'Cannot find module `scroll-into-view-if-needed`'

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prettier-plugin-svelte": "^2.7.0",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.0.1",
-    "scroll-into-view-if-needed": "^2.2.29",
     "svelte": "^3.49.0",
     "svelte-check": "^2.8.0",
     "svelte-github-corner": "^0.1.0",

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -244,7 +244,10 @@
         // around start/end of option list. Find a better solution than waiting 10 ms to.
         setTimeout(() => {
           const li = document.querySelector(`ul.options > li.active`)
-          if (li) li.scrollIntoViewIfNeeded()
+          if (li) {
+            li.parentNode?.scrollIntoView({ block: `center` })
+            li.scrollIntoViewIfNeeded()
+          }
         }, 10)
       }
     }

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import scrollIntoView from 'scroll-into-view-if-needed'
   import { createEventDispatcher } from 'svelte'
   import type { DispatchEvents, MultiSelectEvents, Option } from './'
   import { get_label, get_value } from './'
@@ -245,7 +244,7 @@
         // around start/end of option list. Find a better solution than waiting 10 ms to.
         setTimeout(() => {
           const li = document.querySelector(`ul.options > li.active`)
-          if (li) scrollIntoView(li, { scrollMode: `if-needed` })
+          if (li) li.scrollIntoViewIfNeeded()
         }, 10)
       }
     }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -36,3 +36,27 @@ export const get_label = (op: Option) => (op instanceof Object ? op.label : op)
 // fallback on label if option is object and value is undefined
 export const get_value = (op: Option) =>
   op instanceof Object ? op.value ?? op.label : op
+
+// Firefox lacks support for scrollIntoViewIfNeeded, see
+// https://github.com/janosh/svelte-multiselect/issues/87
+// this polyfill was copied from
+// https://github.com/nuxodin/lazyfill/blob/a8e63/polyfills/Element/prototype/scrollIntoViewIfNeeded.js
+if (
+  typeof Element !== `undefined` &&
+  !Element.prototype?.scrollIntoViewIfNeeded
+) {
+  Element.prototype.scrollIntoViewIfNeeded = function (centerIfNeeded = true) {
+    const el = this as Element
+    new IntersectionObserver(function ([entry]) {
+      const ratio = entry.intersectionRatio
+      if (ratio < 1) {
+        const place = ratio <= 0 && centerIfNeeded ? `center` : `nearest`
+        el.scrollIntoView({
+          block: place,
+          inline: place,
+        })
+      }
+      this.disconnect()
+    }).observe(this)
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
-// https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,6 @@ export default {
   plugins: [sveltekit()],
   test: {
     environment: `jsdom`,
-    deps: {
-      inline: [`compute-scroll-into-view`],
-    },
   },
   resolve: {
     alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,11 +445,6 @@ comma-separated-tokens@^2.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz#d4c25abb679b7751c880be623c1179780fe1dd98"
   integrity sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==
 
-compute-scroll-into-view@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
-  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1647,13 +1642,6 @@ saxes@^6.0.0:
   integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
   dependencies:
     xmlchars "^2.2.0"
-
-scroll-into-view-if-needed@^2.2.29:
-  version "2.2.29"
-  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz#551791a84b7e2287706511f8c68161e4990ab885"
-  integrity sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==
-  dependencies:
-    compute-scroll-into-view "^1.0.17"
 
 semver@^7.3.7:
   version "7.3.7"


### PR DESCRIPTION
Closes #98.

Remove `scroll-into-view-if-needed` package and define `Element.prototype.scrollIntoViewIfNeeded` in `src/lib/index.ts` if missing.