### PR TITLE
Add SCSS preprocessing 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prettier-plugin-svelte": "^2.7.0",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.0.1",
+    "sass": "^1.55.0",
     "svelte": "^3.50.1",
     "svelte-check": "^2.9.0",
     "svelte-github-corner": "^0.1.0",

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -479,144 +479,159 @@
   {/if}
 </div>
 
-<style>
-  :where(div.multiselect) {
-    position: relative;
-    align-items: center;
-    display: flex;
-    cursor: text;
-    border: var(--sms-border, 1pt solid lightgray);
-    border-radius: var(--sms-border-radius, 3pt);
-    background: var(--sms-bg);
-    max-width: var(--sms-max-width);
-    padding: var(--sms-padding, 0 3pt);
-    color: var(--sms-text-color);
-    font-size: var(--sms-font-size, inherit);
-    min-height: var(--sms-min-height, 19pt);
-    margin: var(--sms-margin);
-  }
-  :where(div.multiselect.open) {
-    /* increase z-index when open to ensure the dropdown of one <MultiSelect />
+<style lang="scss">
+  @mixin default_styles() {
+    & {
+      position: relative;
+      align-items: center;
+      display: flex;
+      cursor: text;
+      border: var(--sms-border, 1pt solid lightgray);
+      border-radius: var(--sms-border-radius, 3pt);
+      background: var(--sms-bg);
+      max-width: var(--sms-max-width);
+      padding: var(--sms-padding, 0 3pt);
+      color: var(--sms-text-color);
+      font-size: var(--sms-font-size, inherit);
+      min-height: var(--sms-min-height, 19pt);
+      margin: var(--sms-margin);
+    }
+    &.open {
+      /* increase z-index when open to ensure the dropdown of one <MultiSelect />
     displays above that of another slightly below it on the page */
-    z-index: var(--sms-open-z-index, 4);
-  }
-  :where(div.multiselect:focus-within) {
-    border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));
-  }
-  :where(div.multiselect.disabled) {
-    background: var(--sms-disabled-bg, lightgray);
-    cursor: not-allowed;
+      z-index: var(--sms-open-z-index, 4);
+    }
+    &:focus-within {
+      border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));
+    }
+    &.disabled {
+      background: var(--sms-disabled-bg, lightgray);
+      cursor: not-allowed;
+    }
+
+    & > ul.selected {
+      display: flex;
+      flex: 1;
+      padding: 0;
+      margin: 0;
+      flex-wrap: wrap;
+    }
+    & > ul.selected > li {
+      align-items: center;
+      border-radius: 3pt;
+      display: flex;
+      margin: 2pt;
+      line-height: normal;
+      transition: 0.3s;
+      white-space: nowrap;
+      background: var(--sms-selected-bg, rgba(0, 0, 0, 0.15));
+      padding: var(--sms-selected-li-padding, 1pt 5pt);
+      color: var(--sms-selected-text-color, var(--sms-text-color));
+    }
+    & button {
+      border-radius: 50%;
+      display: flex;
+      transition: 0.2s;
+      color: inherit;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      outline: none;
+      padding: 0;
+      margin: 0 0 0 3pt; /* CSS reset */
+    }
+    & button.remove-all {
+      margin: 0 3pt;
+    }
+    ul.selected > li button:hover,
+    button.remove-all:hover,
+    button:focus {
+      color: var(--sms-button-hover-color, lightskyblue);
+    }
+
+    & input {
+      margin: auto 0; /* CSS reset */
+      padding: 0; /* CSS reset */
+    }
+    & > ul.selected > li > input {
+      border: none;
+      outline: none;
+      background: none;
+      flex: 1; /* this + next line fix issue #12 https://git.io/JiDe3 */
+      min-width: 2em;
+      /* ensure input uses text color and not --sms-selected-text-color */
+      color: var(--sms-text-color);
+      font-size: inherit;
+      cursor: inherit; /* needed for disabled state */
+      border-radius: 0; /* reset ul.selected > li */
+    }
+    & > ul.selected > li > input::placeholder {
+      padding-left: 5pt;
+      color: var(--sms-placeholder-color);
+      opacity: var(--sms-placeholder-opacity);
+    }
+    & > input.form-control {
+      width: 2em;
+      position: absolute;
+      background: transparent;
+      border: none;
+      outline: none;
+      z-index: -1;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    & > ul.options {
+      list-style: none;
+      padding: 4pt 0;
+      top: 100%;
+      left: 0;
+      width: 100%;
+      position: absolute;
+      border-radius: 1ex;
+      overflow: auto;
+      background: var(--sms-options-bg, white);
+      max-height: var(--sms-options-max-height, 50vh);
+      overscroll-behavior: var(--sms-options-overscroll, none);
+      box-shadow: var(--sms-options-shadow, 0 0 14pt -8pt black);
+      transition: all 0.2s;
+    }
+    & > ul.options.hidden {
+      visibility: hidden;
+      opacity: 0;
+      transform: translateY(50px);
+    }
+    & > ul.options > li {
+      padding: 3pt 2ex;
+      cursor: pointer;
+      scroll-margin: var(--sms-options-scroll-margin, 100px);
+    }
+    & > ul.options span {
+      // for noOptionsMsg
+      padding: 3pt 2ex;
+    }
+    & > ul.options > li.selected {
+      background: var(--sms-li-selected-bg);
+      color: var(--sms-li-selected-color);
+    }
+    & > ul.options > li.active {
+      background: var(--sms-li-active-bg, var(--sms-active-color, rgba(0, 0, 0, 0.15)));
+    }
+    & > ul.options > li.disabled {
+      cursor: not-allowed;
+      background: var(--sms-li-disabled-bg, #f5f5f6);
+      color: var(--sms-li-disabled-text, #b8b8b8);
+    }
   }
 
-  :where(div.multiselect > ul.selected) {
-    display: flex;
-    flex: 1;
-    padding: 0;
-    margin: 0;
-    flex-wrap: wrap;
-  }
-  :where(div.multiselect > ul.selected > li) {
-    align-items: center;
-    border-radius: 3pt;
-    display: flex;
-    margin: 2pt;
-    line-height: normal;
-    transition: 0.3s;
-    white-space: nowrap;
-    background: var(--sms-selected-bg, rgba(0, 0, 0, 0.15));
-    padding: var(--sms-selected-li-padding, 1pt 5pt);
-    color: var(--sms-selected-text-color, var(--sms-text-color));
-  }
-  :where(div.multiselect button) {
-    border-radius: 50%;
-    display: flex;
-    transition: 0.2s;
-    color: inherit;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    outline: none;
-    padding: 0;
-    margin: 0 0 0 3pt; /* CSS reset */
-  }
-  :where(div.multiselect button.remove-all) {
-    margin: 0 3pt;
-  }
-  :where(ul.selected > li button:hover, button.remove-all:hover, button:focus) {
-    color: var(--sms-button-hover-color, lightskyblue);
+  :where(div.multiselect) {
+    @include default_styles();
   }
 
-  :where(div.multiselect input) {
-    margin: auto 0; /* CSS reset */
-    padding: 0; /* CSS reset */
-  }
-  :where(div.multiselect > ul.selected > li > input) {
-    border: none;
-    outline: none;
-    background: none;
-    flex: 1; /* this + next line fix issue #12 https://git.io/JiDe3 */
-    min-width: 2em;
-    /* ensure input uses text color and not --sms-selected-text-color */
-    color: var(--sms-text-color);
-    font-size: inherit;
-    cursor: inherit; /* needed for disabled state */
-    border-radius: 0; /* reset ul.selected > li */
-  }
-  :where(div.multiselect > ul.selected > li > input)::placeholder {
-    padding-left: 5pt;
-    color: var(--sms-placeholder-color);
-    opacity: var(--sms-placeholder-opacity);
-  }
-  :where(div.multiselect > input.form-control) {
-    width: 2em;
-    position: absolute;
-    background: transparent;
-    border: none;
-    outline: none;
-    z-index: -1;
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  :where(div.multiselect > ul.options) {
-    list-style: none;
-    padding: 4pt 0;
-    top: 100%;
-    left: 0;
-    width: 100%;
-    position: absolute;
-    border-radius: 1ex;
-    overflow: auto;
-    background: var(--sms-options-bg, white);
-    max-height: var(--sms-options-max-height, 50vh);
-    overscroll-behavior: var(--sms-options-overscroll, none);
-    box-shadow: var(--sms-options-shadow, 0 0 14pt -8pt black);
-    transition: all 0.2s;
-  }
-  :where(div.multiselect > ul.options.hidden) {
-    visibility: hidden;
-    opacity: 0;
-    transform: translateY(50px);
-  }
-  :where(div.multiselect > ul.options > li) {
-    padding: 3pt 2ex;
-    cursor: pointer;
-    scroll-margin: var(--sms-options-scroll-margin, 100px);
-  }
-  /* for noOptionsMsg */
-  :where(div.multiselect > ul.options span) {
-    padding: 3pt 2ex;
-  }
-  :where(div.multiselect > ul.options > li.selected) {
-    background: var(--sms-li-selected-bg);
-    color: var(--sms-li-selected-color);
-  }
-  :where(div.multiselect > ul.options > li.active) {
-    background: var(--sms-li-active-bg, var(--sms-active-color, rgba(0, 0, 0, 0.15)));
-  }
-  :where(div.multiselect > ul.options > li.disabled) {
-    cursor: not-allowed;
-    background: var(--sms-li-disabled-bg, #f5f5f6);
-    color: var(--sms-li-disabled-text, #b8b8b8);
+  // https://github.com/janosh/svelte-multiselect/issues/117
+  @supports not selector(:where(div.multiselect)) {
+    div.multiselect {
+      @include default_styles();
+    }
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores'
   import GitHubCorner from 'svelte-github-corner'
   import '../app.css'
-  import { demo_routes } from './demos'
+  import { demo_routes } from './+layout'
 
   $: isCurrent = (path: string) => {
     if (path === $page.url.pathname) return `page`

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,8 @@
 export const prerender = true
+
+export const demo_routes = Object.keys(import.meta.glob(`./**/*.svx`)).map(
+  (filename) => filename.split(`.`)[1].replace(`/+page`, ``)
+)
+if (demo_routes.length < 5) {
+  throw new Error(`Too few demo routes found: ${demo_routes.length}`)
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import Toc from 'svelte-toc'
   import Readme from '../../readme.md'
   import Examples from '../components/Examples.svelte'
-  import { demo_routes } from './demos'
+  import { demo_routes } from './+layout'
 </script>
 
 <main>

--- a/src/routes/demos.ts
+++ b/src/routes/demos.ts
@@ -1,6 +1,0 @@
-export const demo_routes = Object.keys(import.meta.glob(`./**/*.svx`)).map(
-  (filename) => filename.split(`.`)[1].replace(`/+page`, ``)
-)
-if (demo_routes.length < 5) {
-  throw `Too few demo routes found: ${demo_routes.length}`
-}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,7 +26,7 @@ export default {
   extensions: [`.svelte`, `.svx`, `.md`],
 
   preprocess: [
-    preprocess(),
+    preprocess({ sass: false, scss: true }),
     mdsvex({ rehypePlugins, extensions: [`.svx`, `.md`] }),
   ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,7 +454,7 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
-chokidar@^3.4.1, chokidar@^3.5.3:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -1179,6 +1179,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+immutable@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -1793,6 +1798,15 @@ sander@^0.5.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
+sass@^1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.55.0.tgz#0c4d3c293cfe8f8a2e8d3b666e1cf1bff8065d1c"
+  integrity sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 saxes@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
@@ -1848,7 +1862,7 @@ sorcery@^0.10.0:
     sander "^0.5.0"
     sourcemap-codec "^1.3.0"
 
-source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
Closes #117.

Use SCSS to define `@mixin` for default component styles that gets wrapped in `:where()` if browser supports it, else gets applied anyway but without wrapping in `:where()`, thereby losing recessive scoping. (Big thanks to @Prinzhorn for the suggestion.)

Note to consumers: If you need to support Edge 87 and earlier and also want to override default component styles, apply the `!important` keyword to every CSS rule you add. See the discussion in https://github.com/sveltejs/svelte/issues/7907#issuecomment-1268575262.

```diff
div.multiselect {
-  margin: 1em;
+  margin: 1em !important;
}
```