### PR TITLE
Add unit tests for 2-/1-way binding of `activeIndex` and `activeOption`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
+          node-version: 18
           cache: pnpm
 
       - name: Install dependencies
@@ -40,6 +41,5 @@ jobs:
         if: github.event_name == 'release' && steps.tests.outcome == 'success' && runner.os == 'Linux'
         run: |
           pnpm package
-          pnpm publish package
-        env:
+          npm publish ./package
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ Favorite Frontend Frameworks?
 
 ## Props
 
-Full list of props/bindable variables for this component. The `Option` type you see below is defined in [`src/lib/index.ts`](src/lib/index.ts) and can be imported as `import { type Option } from 'svelte-multiselect'`.
+Full list of props/bindable variables for this component. The `Option` type you see below is defined in [`src/lib/index.ts`](https://github.com/janosh/svelte-multiselect/blob/main/src/lib/index.ts) and can be imported as `import { type Option } from 'svelte-multiselect'`.
 
 1. ```ts
    activeIndex: number | null = null

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@
 
 ```sh
 npm install -D svelte-multiselect
-pnpm install -D svelte-multiselect
+pnpm add -D svelte-multiselect
 yarn add -D svelte-multiselect
 ```
 
@@ -73,11 +73,7 @@ Favorite Frontend Frameworks?
 
 ## Props
 
-Full list of props/bindable variables for this component. In the type hints below, `Option` is:
-
-```ts
-import type { Option } from 'svelte-multiselect'
-```
+Full list of props/bindable variables for this component. The `Option` type you see below is defined in [`src/lib/index.ts`](src/lib/index.ts) and can be imported as `import { type Option } from 'svelte-multiselect'`.
 
 1. ```ts
    activeIndex: number | null = null

--- a/tests/unit/Test2WayBind.svelte
+++ b/tests/unit/Test2WayBind.svelte
@@ -2,18 +2,27 @@
   import MultiSelect, { type Option } from '$lib'
   import { createEventDispatcher } from 'svelte'
 
+  export let activeIndex: number | null = null
   export let activeOption: Option | null = null
-  export let selected: Option[] = []
-  export let options: Option[]
-  export let value: Option | Option[] | null = null
   export let maxSelect: number | null = null
+  export let options: Option[]
+  export let selected: Option[] = []
+  export let value: Option | Option[] | null = null
 
   const dispatch = createEventDispatcher()
 
+  $: dispatch(`activeIndex-changed`, activeIndex)
   $: dispatch(`activeOption-changed`, activeOption)
   $: dispatch(`options-changed`, options)
   $: dispatch(`selected-changed`, selected)
   $: dispatch(`value-changed`, value)
 </script>
 
-<MultiSelect bind:options bind:selected bind:value {maxSelect} bind:activeOption />
+<MultiSelect
+  {maxSelect}
+  bind:activeIndex
+  bind:activeOption
+  bind:options
+  bind:selected
+  bind:value
+/>

--- a/tests/unit/Test2WayBind.svelte
+++ b/tests/unit/Test2WayBind.svelte
@@ -2,16 +2,18 @@
   import MultiSelect, { type Option } from '$lib'
   import { createEventDispatcher } from 'svelte'
 
+  export let activeOption: Option | null = null
   export let selected: Option[] = []
-  export let options: Option[] = [1, 2, 3]
+  export let options: Option[]
   export let value: Option | Option[] | null = null
   export let maxSelect: number | null = null
 
   const dispatch = createEventDispatcher()
 
+  $: dispatch(`activeOption-changed`, activeOption)
   $: dispatch(`options-changed`, options)
   $: dispatch(`selected-changed`, selected)
   $: dispatch(`value-changed`, value)
 </script>
 
-<MultiSelect bind:options bind:selected bind:value {maxSelect} />
+<MultiSelect bind:options bind:selected bind:value {maxSelect} bind:activeOption />

--- a/tests/unit/multiselect.test.ts
+++ b/tests/unit/multiselect.test.ts
@@ -16,6 +16,28 @@ function doc_query(selector: string) {
   return res
 }
 
+test(`1-way binding of activeOption and hovering an option makes it active`, async () => {
+  const binder = new Test2WayBind({
+    target: document.body,
+    props: { options: [1, 2, 3] },
+  })
+
+  // test internal change to activeOption binds outwards
+  let activeOption: Option
+  binder.$on(`activeOption-changed`, (e: CustomEvent) => {
+    activeOption = e.detail
+  })
+  const cb = vi.fn()
+  binder.$on(`activeOption-changed`, cb)
+
+  const first_option = doc_query(`ul.options > li`)
+  first_option.dispatchEvent(new MouseEvent(`mouseover`))
+
+  await sleep()
+  expect(activeOption).toBe(1)
+  expect(cb).toBeCalledTimes(1)
+})
+
 test(`defaultDisabledTitle and custom per-option disabled titles are applied correctly`, () => {
   const defaultDisabledTitle = `Not selectable`
   const special_disabled_title = `Special disabled title`
@@ -543,7 +565,7 @@ test(`2-way bind selected`, async () => {
     selected = e.detail
   })
 
-  // test internal changes bind outwards
+  // test internal changes to selected bind outwards
   for (const _ of [1, 2]) {
     const li = doc_query(`ul.options li`)
     li.dispatchEvent(new MouseEvent(`mouseup`))
@@ -552,7 +574,7 @@ test(`2-way bind selected`, async () => {
 
   expect(selected).toEqual([1, 2])
 
-  // test external changes bind inwards
+  // test external changes to selected bind inwards
   selected = [3]
   binder.$set({ selected })
   await sleep()

--- a/tests/unit/multiselect.test.ts
+++ b/tests/unit/multiselect.test.ts
@@ -16,533 +16,563 @@ function doc_query(selector: string) {
   return res
 }
 
-describe(`MultiSelect`, () => {
-  test(`defaultDisabledTitle and custom per-option disabled titles are applied correctly`, () => {
-    const defaultDisabledTitle = `Not selectable`
-    const special_disabled_title = `Special disabled title`
-    const options = [1, 2, 3].map((el) => ({
-      label: el,
-      disabled: true,
-      disabledTitle: el > 1 ? undefined : special_disabled_title,
-    }))
+test(`defaultDisabledTitle and custom per-option disabled titles are applied correctly`, () => {
+  const defaultDisabledTitle = `Not selectable`
+  const special_disabled_title = `Special disabled title`
+  const options = [1, 2, 3].map((el) => ({
+    label: el,
+    disabled: true,
+    disabledTitle: el > 1 ? undefined : special_disabled_title,
+  }))
 
-    new MultiSelect({
-      target: document.body,
-      props: { options, defaultDisabledTitle },
-    })
-
-    const lis = document.querySelectorAll(`ul.options > li`)
-
-    expect(lis.length).toBe(3)
-
-    expect([...lis].map((li) => li.title)).toEqual([
-      special_disabled_title,
-      defaultDisabledTitle,
-      defaultDisabledTitle,
-    ])
+  new MultiSelect({
+    target: document.body,
+    props: { options, defaultDisabledTitle },
   })
 
-  test(`applies DOM attributes to input node`, () => {
-    const searchText = `1`
-    const id = `fancy-id`
-    const autocomplete = `on`
-    const name = `fancy-name`
-    const placeholder = `fancy placeholder`
-    const inputmode = `tel`
-    const pattern = `(reg)[ex]`
+  const lis = document.querySelectorAll(`ul.options > li`)
 
-    new MultiSelect({
-      target: document.body,
-      props: {
-        options: [1, 2, 3],
-        searchText,
-        id,
-        autocomplete,
-        placeholder,
-        name,
-        inputmode,
-        pattern,
-      },
-    })
+  expect(lis.length).toBe(3)
 
-    const lis = document.querySelectorAll(`ul.options > li`)
-    const input = doc_query(`ul.selected input`) as HTMLInputElement
+  expect([...lis].map((li) => li.title)).toEqual([
+    special_disabled_title,
+    defaultDisabledTitle,
+    defaultDisabledTitle,
+  ])
+})
 
-    // make sure the search text filtered the dropdown options
-    expect(lis.length).toBe(1)
+test(`applies DOM attributes to input node`, () => {
+  const searchText = `1`
+  const id = `fancy-id`
+  const autocomplete = `on`
+  const name = `fancy-name`
+  const placeholder = `fancy placeholder`
+  const inputmode = `tel`
+  const pattern = `(reg)[ex]`
 
-    expect(input?.value).toBe(searchText)
-    expect(input?.id).toBe(id)
-    expect(input?.autocomplete).toBe(autocomplete)
-    expect(input?.placeholder).toBe(placeholder)
-    expect(input?.name).toBe(name)
-    expect(input?.inputMode).toBe(inputmode)
-    expect(input?.pattern).toBe(pattern)
+  new MultiSelect({
+    target: document.body,
+    props: {
+      options: [1, 2, 3],
+      searchText,
+      id,
+      autocomplete,
+      placeholder,
+      name,
+      inputmode,
+      pattern,
+    },
   })
 
-  test(`applies custom classes for styling through CSS frameworks`, () => {
-    const css_classes = {
-      input: HTMLInputElement,
-      liOption: HTMLLIElement,
-      liSelected: HTMLLIElement,
-      outerDiv: HTMLDivElement,
-      ulOptions: HTMLUListElement,
-      ulSelected: HTMLUListElement,
+  const lis = document.querySelectorAll(`ul.options > li`)
+  const input = doc_query(`ul.selected input`) as HTMLInputElement
+
+  // make sure the search text filtered the dropdown options
+  expect(lis.length).toBe(1)
+
+  expect(input?.value).toBe(searchText)
+  expect(input?.id).toBe(id)
+  expect(input?.autocomplete).toBe(autocomplete)
+  expect(input?.placeholder).toBe(placeholder)
+  expect(input?.name).toBe(name)
+  expect(input?.inputMode).toBe(inputmode)
+  expect(input?.pattern).toBe(pattern)
+})
+
+test(`applies custom classes for styling through CSS frameworks`, async () => {
+  const prop_elem_map = {
+    input: HTMLInputElement,
+    liOption: HTMLLIElement,
+    liActiveOption: HTMLLIElement,
+    liSelected: HTMLLIElement,
+    outerDiv: HTMLDivElement,
+    ulOptions: HTMLUListElement,
+    ulSelected: HTMLUListElement,
+  }
+  const css_classes = Object.fromEntries(
+    Object.keys(prop_elem_map).map((cls) => [`${cls}Class`, cls])
+  )
+
+  new MultiSelect({
+    target: document.body,
+    // select 1 to make sure the selected list is rendered
+    props: { options: [1, 2, 3], ...css_classes, selected: [1] },
+  })
+
+  // make an option active hovering it so it gets the active class
+  document
+    .querySelector(`ul.options > li`)
+    ?.dispatchEvent(new MouseEvent(`mouseover`, { bubbles: true }))
+  await sleep()
+
+  for (const [class_name, elem_type] of Object.entries(prop_elem_map)) {
+    const el = doc_query(`.${class_name}`)
+
+    expect(el).toBeInstanceOf(elem_type)
+  }
+})
+
+// https://github.com/janosh/svelte-multiselect/issues/111
+test(`arrow down makes first option active`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: { options: [1, 2, 3], open: true },
+  })
+
+  const input = doc_query(`ul.selected input`)
+
+  input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown` }))
+
+  await sleep()
+
+  const active_option = doc_query(`ul.options > li.active`)
+
+  expect(active_option.textContent?.trim()).toBe(`1`)
+})
+
+// https://github.com/janosh/svelte-multiselect/issues/112
+test(`can select 1st and last option with arrow and enter key`, async () => {
+  new MultiSelect({ target: document.body, props: { options: [1, 2, 3] } })
+
+  const input = doc_query(`ul.selected input`)
+
+  input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown` }))
+  await sleep()
+  input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter` }))
+  await sleep()
+  const selected = doc_query(`ul.selected`)
+
+  expect(selected.textContent?.trim()).toBe(`1`)
+
+  input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowUp` }))
+  await sleep()
+  input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter` }))
+  await sleep()
+
+  expect(selected.textContent?.trim()).toBe(`1 3`)
+})
+
+// https://github.com/janosh/svelte-multiselect/issues/119
+test(`invokes callback functions on input node DOM events`, async () => {
+  const options = [1, 2, 3]
+
+  const events: [keyof MultiSelectEvents, Event][] = [
+    [`blur`, new FocusEvent(`blur`)],
+    [`click`, new MouseEvent(`click`)],
+    [`focus`, new FocusEvent(`focus`)],
+    [`keydown`, new KeyboardEvent(`keydown`, { key: `Enter` })],
+    [`keyup`, new KeyboardEvent(`keyup`, { key: `Enter` })],
+    [`mouseenter`, new MouseEvent(`mouseenter`)],
+    [`mouseleave`, new MouseEvent(`mouseleave`)],
+    [`touchend`, new TouchEvent(`touchend`)],
+    [`touchmove`, new TouchEvent(`touchmove`)],
+    [`touchstart`, new TouchEvent(`touchstart`)],
+  ]
+
+  const instance = new MultiSelect({
+    target: document.body,
+    props: { options },
+  })
+
+  const input = doc_query(`ul.selected input`)
+
+  for (const [event_name, event] of events) {
+    const callback = vi.fn()
+    instance.$on(event_name, callback)
+
+    input.dispatchEvent(event)
+    expect(callback, `event type '${event_name}'`).toHaveBeenCalledTimes(1)
+    expect(callback, `event type '${event_name}'`).toHaveBeenCalledWith(event)
+  }
+})
+
+test(`value is a single option (i.e. selected[0]) when maxSelect=1`, async () => {
+  const options = [1, 2, 3]
+
+  const instance = new MultiSelect({
+    target: document.body,
+    props: { options, maxSelect: 1, selected: options },
+  })
+
+  const value = instance.$$.ctx[instance.$$.props.value]
+
+  // this also tests that only 1st option is pre-selected although all options are marked such, i.e. no more than maxSelect options can be pre-selected
+  expect(value).toBe(options[0])
+})
+
+test(`selected is null when maxSelect=1 and no option is pre-selected`, async () => {
+  const instance = new MultiSelect({
+    target: document.body,
+    props: { options: [1, 2, 3], maxSelect: 1 },
+  })
+
+  const value = instance.$$.ctx[instance.$$.props.value]
+
+  expect(value).toBe(null)
+})
+
+test(`selected is array of first two options when maxSelect=2`, async () => {
+  // even though all options have preselected=true
+  const options = [1, 2, 3].map((itm) => ({
+    label: itm,
+    preselected: true,
+  }))
+
+  const instance = new MultiSelect({
+    target: document.body,
+    props: { options, maxSelect: 2 },
+  })
+
+  const selected = instance.$$.ctx[instance.$$.props.selected]
+
+  expect(selected).toEqual(options.slice(0, 2))
+})
+
+describe.each([
+  [[], false], // empty selected = invalid form
+  [[1], true], // at least 1 selected = valid form
+])(`required MultiSelect`, (selected, form_valid) => {
+  test.each([1, 2, null])(
+    `${
+      form_valid ? `does` : `doesn't`
+    } pass validity check if selected=${selected} and maxSelect=%s`,
+    (maxSelect) => {
+      // i think, not passing validity check means form won't submit
+      // maybe TODO: simulating form submission event and checking
+      // event.defaultPrevented == true seems closer to ground truth but harder to test
+
+      const form = document.createElement(`form`)
+      document.body.appendChild(form)
+
+      new MultiSelect({
+        target: form,
+        props: { options: [1, 2, 3], required: true, selected, maxSelect },
+      })
+
+      expect(form.checkValidity()).toBe(form_valid)
     }
-    const prop_classes = Object.fromEntries(
-      Object.keys(css_classes).map((cls) => [`${cls}Class`, cls])
-    )
+  )
+})
 
-    new MultiSelect({
-      target: document.body,
-      // select 1 to make sure the selected list is rendered
-      props: { options: [1, 2, 3], ...prop_classes, selected: [1] },
-    })
+test(`required and non-empty MultiSelect makes form pass validity check`, async () => {
+  const form = document.createElement(`form`)
+  document.body.appendChild(form)
 
-    // TODO also test liActiveOptionClass once figured out how to make an option active
-    // this doesn't work for unknown reasons
-    // document
-    //   .querySelector(`ul.options > li`)
-    //   ?.dispatchEvent(new MouseEvent(`mouseover`, { bubbles: true }))
-
-    for (const [class_name, elem_type] of Object.entries(css_classes)) {
-      const el = doc_query(`.${class_name}`)
-
-      expect(el).toBeInstanceOf(elem_type)
-    }
+  new MultiSelect({
+    target: form,
+    props: { options: [1, 2, 3], required: true, selected: [1] },
   })
 
-  // https://github.com/janosh/svelte-multiselect/issues/111
-  test(`arrow down makes first option active`, async () => {
-    new MultiSelect({
+  expect(form.checkValidity()).toBe(true)
+})
+
+test(`div has 'invalid' class and input is aria-invalid when invalid=true`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: { options: [1, 2, 3], invalid: true },
+  })
+
+  const input = doc_query(`ul.selected input`)
+
+  expect(input.getAttribute(`aria-invalid`)).toBe(`true`)
+  const multiselect = doc_query(`div.multiselect`)
+  expect(multiselect.classList.contains(`invalid`)).toBe(true)
+
+  // assert aria-invalid attribute is removed on selecting a new option
+  const option = doc_query(`ul.options > li`)
+  option.dispatchEvent(new MouseEvent(`mouseup`))
+  await sleep()
+
+  expect(input.getAttribute(`aria-invalid`)).toBe(null)
+
+  // assert div.multiselect no longer has invalid class
+  expect(multiselect.classList.contains(`invalid`)).toBe(false)
+})
+
+test(`parseLabelsAsHtml renders anchor tags as links`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: {
+      options: [`<a href="https://example.com">example.com</a>`],
+      parseLabelsAsHtml: true,
+    },
+  })
+
+  const anchor = doc_query(`a[href='https://example.com']`)
+  expect(anchor).toBeInstanceOf(HTMLAnchorElement)
+})
+
+test(`filters dropdown to show only matching options when entering text`, async () => {
+  const options = [`foo`, `bar`, `baz`]
+
+  new MultiSelect({
+    target: document.body,
+    props: { options },
+  })
+
+  const input = doc_query(`ul.selected input`)
+
+  input.value = `ba`
+  input.dispatchEvent(new InputEvent(`input`))
+  await sleep()
+
+  const dropdown = doc_query(`ul.options`)
+  expect(dropdown.textContent?.trim()).toBe(`bar baz`)
+})
+
+// test default case and custom message
+test.each([undefined, `Custom no options message`])(
+  `shows noMatchingOptionsMsg when no options match searchText`,
+  async (noMatchingOptionsMsg) => {
+    const select = new MultiSelect({
       target: document.body,
-      props: { options: [1, 2, 3], open: true },
+      props: { options: [1, 2, 3], noMatchingOptionsMsg },
     })
 
     const input = doc_query(`ul.selected input`)
 
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown` }))
-
-    await sleep()
-
-    const active_option = doc_query(`ul.options > li.active`)
-
-    expect(active_option.textContent?.trim()).toBe(`1`)
-  })
-
-  // https://github.com/janosh/svelte-multiselect/issues/112
-  test(`can select 1st and last option with arrow and enter key`, async () => {
-    new MultiSelect({ target: document.body, props: { options: [1, 2, 3] } })
-
-    const input = doc_query(`ul.selected input`)
-
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowDown` }))
-    await sleep()
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter` }))
-    await sleep()
-    const selected = doc_query(`ul.selected`)
-
-    expect(selected.textContent?.trim()).toBe(`1`)
-
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `ArrowUp` }))
-    await sleep()
-    input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter` }))
-    await sleep()
-
-    expect(selected.textContent?.trim()).toBe(`1 3`)
-  })
-
-  // https://github.com/janosh/svelte-multiselect/issues/119
-  test(`invokes callback functions on input node DOM events`, async () => {
-    const options = [1, 2, 3]
-
-    const events: [keyof MultiSelectEvents, Event][] = [
-      [`blur`, new FocusEvent(`blur`)],
-      [`click`, new MouseEvent(`click`)],
-      [`focus`, new FocusEvent(`focus`)],
-      [`keydown`, new KeyboardEvent(`keydown`, { key: `Enter` })],
-      [`keyup`, new KeyboardEvent(`keyup`, { key: `Enter` })],
-      [`mouseenter`, new MouseEvent(`mouseenter`)],
-      [`mouseleave`, new MouseEvent(`mouseleave`)],
-      [`touchend`, new TouchEvent(`touchend`)],
-      [`touchmove`, new TouchEvent(`touchmove`)],
-      [`touchstart`, new TouchEvent(`touchstart`)],
-    ]
-
-    const instance = new MultiSelect({
-      target: document.body,
-      props: { options },
-    })
-
-    const input = doc_query(`ul.selected input`)
-
-    for (const [event_name, event] of events) {
-      const callback = vi.fn()
-      instance.$on(event_name, callback)
-
-      input.dispatchEvent(event)
-      expect(callback, `event type '${event_name}'`).toHaveBeenCalledTimes(1)
-      expect(callback, `event type '${event_name}'`).toHaveBeenCalledWith(event)
-    }
-  })
-
-  test(`value is a single option (i.e. selected[0]) when maxSelect=1`, async () => {
-    const options = [1, 2, 3]
-
-    const instance = new MultiSelect({
-      target: document.body,
-      props: { options, maxSelect: 1, selected: options },
-    })
-
-    const value = instance.$$.ctx[instance.$$.props.value]
-
-    // this also tests that only 1st option is pre-selected although all options are marked such, i.e. no more than maxSelect options can be pre-selected
-    expect(value).toBe(options[0])
-  })
-
-  test(`selected is null when maxSelect=1 and no option is pre-selected`, async () => {
-    const instance = new MultiSelect({
-      target: document.body,
-      props: { options: [1, 2, 3], maxSelect: 1 },
-    })
-
-    const value = instance.$$.ctx[instance.$$.props.value]
-
-    expect(value).toBe(null)
-  })
-
-  test(`selected is array of first two options when maxSelect=2`, async () => {
-    // even though all options have preselected=true
-    const options = [1, 2, 3].map((itm) => ({
-      label: itm,
-      preselected: true,
-    }))
-
-    const instance = new MultiSelect({
-      target: document.body,
-      props: { options, maxSelect: 2 },
-    })
-
-    const selected = instance.$$.ctx[instance.$$.props.selected]
-
-    expect(selected).toEqual(options.slice(0, 2))
-  })
-
-  describe.each([
-    [[], false], // empty selected = invalid form
-    [[1], true], // at least 1 selected = valid form
-  ])(`required MultiSelect`, (selected, form_valid) => {
-    test.each([1, 2, null])(
-      `${
-        form_valid ? `does` : `doesn't`
-      } pass validity check if selected=${selected} and maxSelect=%s`,
-      (maxSelect) => {
-        // i think, not passing validity check means form won't submit
-        // maybe TODO: simulating form submission event and checking
-        // event.defaultPrevented == true seems closer to ground truth but harder to test
-
-        const form = document.createElement(`form`)
-        document.body.appendChild(form)
-
-        new MultiSelect({
-          target: form,
-          props: { options: [1, 2, 3], required: true, selected, maxSelect },
-        })
-
-        expect(form.checkValidity()).toBe(form_valid)
-      }
-    )
-  })
-
-  test(`required and non-empty MultiSelect makes form pass validity check`, async () => {
-    const form = document.createElement(`form`)
-    document.body.appendChild(form)
-
-    new MultiSelect({
-      target: form,
-      props: { options: [1, 2, 3], required: true, selected: [1] },
-    })
-
-    expect(form.checkValidity()).toBe(true)
-  })
-
-  test(`div has 'invalid' class and input is aria-invalid when invalid=true`, async () => {
-    new MultiSelect({
-      target: document.body,
-      props: { options: [1, 2, 3], invalid: true },
-    })
-
-    const input = doc_query(`ul.selected input`)
-
-    expect(input.getAttribute(`aria-invalid`)).toBe(`true`)
-    const multiselect = doc_query(`div.multiselect`)
-    expect(multiselect.classList.contains(`invalid`)).toBe(true)
-
-    // assert aria-invalid attribute is removed on selecting a new option
-    const option = doc_query(`ul.options > li`)
-    option.dispatchEvent(new MouseEvent(`mouseup`))
-    await sleep()
-
-    expect(input.getAttribute(`aria-invalid`)).toBe(null)
-
-    // assert div.multiselect no longer has invalid class
-    expect(multiselect.classList.contains(`invalid`)).toBe(false)
-  })
-
-  test(`parseLabelsAsHtml renders anchor tags as links`, async () => {
-    new MultiSelect({
-      target: document.body,
-      props: {
-        options: [`<a href="https://example.com">example.com</a>`],
-        parseLabelsAsHtml: true,
-      },
-    })
-
-    const anchor = doc_query(`a[href='https://example.com']`)
-    expect(anchor).toBeInstanceOf(HTMLAnchorElement)
-  })
-
-  test(`filters dropdown to show only matching options when entering text`, async () => {
-    const options = [`foo`, `bar`, `baz`]
-
-    new MultiSelect({
-      target: document.body,
-      props: { options },
-    })
-
-    const input = doc_query(`ul.selected input`)
-
-    input.value = `ba`
+    input.value = `4`
     input.dispatchEvent(new InputEvent(`input`))
     await sleep()
 
+    if (noMatchingOptionsMsg === undefined) {
+      // get default value for noMatchingOptionsMsg
+      noMatchingOptionsMsg = select.$$.ctx[select.$$.props.noMatchingOptionsMsg]
+    }
+
     const dropdown = doc_query(`ul.options`)
-    expect(dropdown.textContent?.trim()).toBe(`bar baz`)
+    expect(dropdown.textContent?.trim()).toBe(noMatchingOptionsMsg)
+  }
+)
+
+test(`single remove button removes 1 selected option`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: { options: [1, 2, 3], selected: [1, 2, 3] },
   })
 
-  // test default case and custom message
-  test.each([undefined, `Custom no options message`])(
-    `shows noMatchingOptionsMsg when no options match searchText`,
-    async (noMatchingOptionsMsg) => {
-      const select = new MultiSelect({
-        target: document.body,
-        props: { options: [1, 2, 3], noMatchingOptionsMsg },
-      })
+  document
+    .querySelector(`ul.selected button[title='Remove 1']`)
+    ?.dispatchEvent(new MouseEvent(`mouseup`))
 
-      const input = doc_query(`ul.selected input`)
+  const selected = doc_query(`ul.selected`)
+  await sleep()
 
-      input.value = `4`
-      input.dispatchEvent(new InputEvent(`input`))
-      await sleep()
+  expect(selected.textContent?.trim()).toEqual(`2 3`)
+})
 
-      if (noMatchingOptionsMsg === undefined) {
-        // get default value for noMatchingOptionsMsg
-        noMatchingOptionsMsg =
-          select.$$.ctx[select.$$.props.noMatchingOptionsMsg]
+test(`remove all button removes all selected options and is visible only if more than 1 option is selected`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: { options: [1, 2, 3], selected: [1, 2, 3] },
+  })
+  let selected = doc_query(`ul.selected`)
+  expect(selected.textContent?.trim()).toEqual(`1 2 3`)
+
+  document
+    .querySelector(`button[title='Remove all']`)
+    ?.dispatchEvent(new MouseEvent(`mouseup`))
+  await sleep()
+
+  selected = doc_query(`ul.selected`)
+  expect(selected.textContent?.trim()).toEqual(``)
+
+  // select 2 options
+  for (const _ of [1, 2]) {
+    expect(
+      document.querySelector(`button[title='Remove all']`),
+      `remove all button should only appear if more than 1 option is selected`
+    ).toBeNull()
+
+    const li = doc_query(`ul.options li`)
+    li.dispatchEvent(new MouseEvent(`mouseup`))
+    await sleep()
+  }
+
+  expect(doc_query(`button[title='Remove all']`)).toBeInstanceOf(
+    HTMLButtonElement
+  )
+})
+
+test(`removeAllTitle and removeBtnTitle are applied correctly`, () => {
+  const removeAllTitle = `Custom remove all title`
+  const removeBtnTitle = `Custom remove button title`
+  const options = [1, 2, 3]
+
+  new MultiSelect({
+    target: document.body,
+    props: { removeAllTitle, removeBtnTitle, options, selected: options },
+  })
+  const remove_all_btn = doc_query(`button.remove-all`) as HTMLButtonElement
+  const remove_btns = document.querySelectorAll(`ul.selected > li > button`)
+
+  expect(remove_all_btn.title).toBe(removeAllTitle)
+  expect([...remove_btns].map((btn) => btn.title)).toEqual(
+    options.map((op) => `${removeBtnTitle} ${op}`)
+  )
+})
+
+test(`can't select disabled options`, async () => {
+  const options = [1, 2, 3].map((el) => ({
+    label: el,
+    disabled: el === 1,
+  }))
+  new MultiSelect({ target: document.body, props: { options } })
+
+  for (const li of document.querySelectorAll(`ul.options > li`)) {
+    li.dispatchEvent(new MouseEvent(`mouseup`))
+  }
+
+  const selected = doc_query(`ul.selected`)
+  await sleep()
+
+  expect(selected.textContent?.trim()).toEqual(`2 3`)
+})
+
+test.each([2, 5, 10])(
+  `cant select more than maxSelect options`,
+  async (maxSelect: number) => {
+    new MultiSelect({
+      target: document.body,
+      props: { options: [...Array(10).keys()], maxSelect },
+    })
+
+    document
+      .querySelectorAll(`ul.options > li`)
+      ?.forEach((li) => li.dispatchEvent(new MouseEvent(`mouseup`)))
+
+    const selected = doc_query(`ul.selected`)
+    await sleep()
+
+    expect(selected.textContent?.trim()).toEqual(
+      [...Array(maxSelect).keys()].join(` `)
+    )
+  }
+)
+
+test(`closes dropdown on tab out`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: { options: [1, 2, 3] },
+  })
+  // starts with closed dropdown
+  expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
+
+  // opens dropdown on focus
+  doc_query(`ul.selected input`).focus()
+  await sleep()
+  expect(document.querySelector(`ul.options.hidden`)).toBeNull()
+
+  // closes dropdown again on tab out
+  doc_query(`ul.selected input`).dispatchEvent(
+    new KeyboardEvent(`keydown`, { key: `Tab` })
+  )
+  await sleep()
+  expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
+})
+
+describe.each([
+  [[`1`, `2`, `3`], [`1`]], // test string options
+  [[1, 2, 3], [1]], // test number options
+])(
+  `shows duplicateOptionMsg when searchText is already selected for options=%j`,
+  (options, selected) => {
+    test.each([
+      [true, `Create this option...`],
+      [false, `Custom duplicate option message`],
+    ])(
+      `allowUserOptions=true, duplicates=%j`,
+      async (duplicates, duplicateOptionMsg) => {
+        new MultiSelect({
+          target: document.body,
+          props: {
+            options,
+            allowUserOptions: true,
+            duplicates,
+            duplicateOptionMsg,
+            selected,
+          },
+        })
+
+        const input = doc_query(`ul.selected input`)
+
+        input.value = selected[0]
+        input.dispatchEvent(new InputEvent(`input`))
+        await sleep()
+
+        const dropdown = doc_query(`ul.options`)
+
+        const fail_msg = `options=${options}, selected=${selected}, duplicates=${duplicates}, duplicateOptionMsg=${duplicateOptionMsg}`
+        expect(dropdown.textContent?.trim(), fail_msg).toBe(duplicateOptionMsg)
       }
-
-      const dropdown = doc_query(`ul.options`)
-      expect(dropdown.textContent?.trim()).toBe(noMatchingOptionsMsg)
-    }
-  )
-
-  test(`single remove button removes 1 selected option`, async () => {
-    new MultiSelect({
-      target: document.body,
-      props: { options: [1, 2, 3], selected: [1, 2, 3] },
-    })
-
-    document
-      .querySelector(`ul.selected button[title='Remove 1']`)
-      ?.dispatchEvent(new MouseEvent(`mouseup`))
-
-    const selected = doc_query(`ul.selected`)
-    await sleep()
-
-    expect(selected.textContent?.trim()).toEqual(`2 3`)
-  })
-
-  test(`remove all button removes all selected options and is visible only if more than 1 option is selected`, async () => {
-    new MultiSelect({
-      target: document.body,
-      props: { options: [1, 2, 3], selected: [1, 2, 3] },
-    })
-    let selected = doc_query(`ul.selected`)
-    expect(selected.textContent?.trim()).toEqual(`1 2 3`)
-
-    document
-      .querySelector(`button[title='Remove all']`)
-      ?.dispatchEvent(new MouseEvent(`mouseup`))
-    await sleep()
-
-    selected = doc_query(`ul.selected`)
-    expect(selected.textContent?.trim()).toEqual(``)
-
-    // select 2 options
-    for (const _ of [1, 2]) {
-      expect(
-        document.querySelector(`button[title='Remove all']`),
-        `remove all button should only appear if more than 1 option is selected`
-      ).toBeNull()
-
-      const li = doc_query(`ul.options li`)
-      li.dispatchEvent(new MouseEvent(`mouseup`))
-      await sleep()
-    }
-
-    expect(doc_query(`button[title='Remove all']`)).toBeInstanceOf(
-      HTMLButtonElement
     )
-  })
+  }
+)
 
-  test(`removeAllTitle and removeBtnTitle are applied correctly`, () => {
-    const removeAllTitle = `Custom remove all title`
-    const removeBtnTitle = `Custom remove button title`
-    const options = [1, 2, 3]
-
+test.each([
+  [true, ``],
+  [false, `1`],
+])(
+  `resetFilterOnAdd=%j handles input value correctly after adding an option`,
+  async (resetFilterOnAdd, expected) => {
     new MultiSelect({
       target: document.body,
-      props: { removeAllTitle, removeBtnTitle, options, selected: options },
+      props: { options: [1, 2, 3], resetFilterOnAdd },
     })
-    const remove_all_btn = doc_query(`button.remove-all`) as HTMLButtonElement
-    const remove_btns = document.querySelectorAll(`ul.selected > li > button`)
 
-    expect(remove_all_btn.title).toBe(removeAllTitle)
-    expect([...remove_btns].map((btn) => btn.title)).toEqual(
-      options.map((op) => `${removeBtnTitle} ${op}`)
-    )
-  })
-
-  test(`can't select disabled options`, async () => {
-    const options = [1, 2, 3].map((el) => ({
-      label: el,
-      disabled: el === 1,
-    }))
-    new MultiSelect({ target: document.body, props: { options } })
-
-    for (const li of document.querySelectorAll(`ul.options > li`)) {
-      li.dispatchEvent(new MouseEvent(`mouseup`))
-    }
-
-    const selected = doc_query(`ul.selected`)
+    const input = doc_query(`ul.selected input`)
+    input.value = `1`
+    input.dispatchEvent(new InputEvent(`input`))
     await sleep()
 
-    expect(selected.textContent?.trim()).toEqual(`2 3`)
+    const li = doc_query(`ul.options li`)
+    li.dispatchEvent(new MouseEvent(`mouseup`))
+    await sleep()
+
+    expect(input.value).toBe(expected)
+  }
+)
+
+test(`2-way bind selected`, async () => {
+  let selected: Option[]
+  const binder = new Test2WayBind({
+    target: document.body,
+    props: { options: [1, 2, 3] },
+  })
+  binder.$on(`selected-changed`, (e: CustomEvent) => {
+    selected = e.detail
   })
 
-  test.each([2, 5, 10])(
-    `cant select more than maxSelect options`,
-    async (maxSelect: number) => {
-      new MultiSelect({
-        target: document.body,
-        props: { options: [...Array(10).keys()], maxSelect },
-      })
-
-      document
-        .querySelectorAll(`ul.options > li`)
-        ?.forEach((li) => li.dispatchEvent(new MouseEvent(`mouseup`)))
-
-      const selected = doc_query(`ul.selected`)
-      await sleep()
-
-      expect(selected.textContent?.trim()).toEqual(
-        [...Array(maxSelect).keys()].join(` `)
-      )
-    }
-  )
-
-  test(`closes dropdown on tab out`, async () => {
-    new MultiSelect({
-      target: document.body,
-      props: { options: [1, 2, 3] },
-    })
-    // starts with closed dropdown
-    expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
-
-    // opens dropdown on focus
-    doc_query(`ul.selected input`).focus()
+  // test internal changes bind outwards
+  for (const _ of [1, 2]) {
+    const li = doc_query(`ul.options li`)
+    li.dispatchEvent(new MouseEvent(`mouseup`))
     await sleep()
-    expect(document.querySelector(`ul.options.hidden`)).toBeNull()
+  }
 
-    // closes dropdown again on tab out
-    doc_query(`ul.selected input`).dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `Tab` })
-    )
-    await sleep()
-    expect(doc_query(`ul.options.hidden`)).toBeInstanceOf(HTMLUListElement)
-  })
+  expect(selected).toEqual([1, 2])
 
-  describe.each([
-    [[`1`, `2`, `3`], [`1`]], // test string options
-    [[1, 2, 3], [1]], // test number options
-  ])(
-    `shows duplicateOptionMsg when searchText is already selected for options=%j`,
-    (options, selected) => {
-      test.each([
-        [true, `Create this option...`],
-        [false, `Custom duplicate option message`],
-      ])(
-        `allowUserOptions=true, duplicates=%j`,
-        async (duplicates, duplicateOptionMsg) => {
-          new MultiSelect({
-            target: document.body,
-            props: {
-              options,
-              allowUserOptions: true,
-              duplicates,
-              duplicateOptionMsg,
-              selected,
-            },
-          })
+  // test external changes bind inwards
+  selected = [3]
+  binder.$set({ selected })
+  await sleep()
+  expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`3`)
+})
 
-          const input = doc_query(`ul.selected input`)
-
-          input.value = selected[0]
-          input.dispatchEvent(new InputEvent(`input`))
-          await sleep()
-
-          const dropdown = doc_query(`ul.options`)
-
-          const fail_msg = `options=${options}, selected=${selected}, duplicates=${duplicates}, duplicateOptionMsg=${duplicateOptionMsg}`
-          expect(dropdown.textContent?.trim(), fail_msg).toBe(
-            duplicateOptionMsg
-          )
-        }
-      )
-    }
-  )
-
-  test.each([
-    [true, ``],
-    [false, `1`],
-  ])(
-    `resetFilterOnAdd=%j handles input value correctly after adding an option`,
-    async (resetFilterOnAdd, expected) => {
-      new MultiSelect({
-        target: document.body,
-        props: { options: [1, 2, 3], resetFilterOnAdd },
-      })
-
-      const input = doc_query(`ul.selected input`)
-      input.value = `1`
-      input.dispatchEvent(new InputEvent(`input`))
-      await sleep()
-
-      const li = doc_query(`ul.options li`)
-      li.dispatchEvent(new MouseEvent(`mouseup`))
-      await sleep()
-
-      expect(input.value).toBe(expected)
-    }
-  )
-
-  test(`2-way bind selected`, async () => {
-    let selected: Option[]
+test.each([
+  [null, [1, 2]],
+  [1, 2],
+  [2, [1, 2]],
+])(
+  `1-way bind value when maxSelect=%s, expected value=%s`,
+  async (maxSelect, expected) => {
     const binder = new Test2WayBind({
       target: document.body,
+      props: { options: [1, 2, 3], maxSelect },
     })
-    binder.$on(`selected-changed`, (e: CustomEvent) => {
-      selected = e.detail
+    let value: Option[]
+    binder.$on(`value-changed`, (e: CustomEvent) => {
+      value = e.detail
     })
 
     // test internal changes bind outwards
@@ -552,39 +582,6 @@ describe(`MultiSelect`, () => {
       await sleep()
     }
 
-    expect(selected).toEqual([1, 2])
-
-    // test external changes bind inwards
-    selected = [3]
-    binder.$set({ selected })
-    await sleep()
-    expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`3`)
-  })
-
-  test.each([
-    [null, [1, 2]],
-    [1, 2],
-    [2, [1, 2]],
-  ])(
-    `1-way bind value when maxSelect=%s, expected value=%s`,
-    async (maxSelect, expected) => {
-      const binder = new Test2WayBind({
-        target: document.body,
-        props: { maxSelect },
-      })
-      let value: Option[]
-      binder.$on(`value-changed`, (e: CustomEvent) => {
-        value = e.detail
-      })
-
-      // test internal changes bind outwards
-      for (const _ of [1, 2]) {
-        const li = doc_query(`ul.options li`)
-        li.dispatchEvent(new MouseEvent(`mouseup`))
-        await sleep()
-      }
-
-      expect(value).toEqual(expected)
-    }
-  )
-})
+    expect(value).toEqual(expected)
+  }
+)


### PR DESCRIPTION
Fix small bug in CI NPM publish step.