### PR TITLE
Revert SCSS preprocessing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
         run: |
           pnpm package
           npm publish ./package
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "prettier-plugin-svelte": "^2.8.0",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.0.1",
-    "sass": "^1.55.0",
     "svelte": "^3.52.0",
     "svelte-check": "^2.9.2",
     "svelte-github-corner": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ specifiers:
   prettier-plugin-svelte: ^2.8.0
   rehype-autolink-headings: ^6.1.1
   rehype-slug: ^5.0.1
-  sass: ^1.55.0
   svelte: ^3.52.0
   svelte-check: ^2.9.2
   svelte-github-corner: ^0.1.0
@@ -48,17 +47,16 @@ devDependencies:
   prettier-plugin-svelte: 2.8.0_lrllcp5xtrkmmdzifit4hd52ze
   rehype-autolink-headings: 6.1.1
   rehype-slug: 5.0.1
-  sass: 1.55.0
   svelte: 3.52.0
-  svelte-check: 2.9.2_sass@1.55.0+svelte@3.52.0
+  svelte-check: 2.9.2_svelte@3.52.0
   svelte-github-corner: 0.1.0
-  svelte-preprocess: 4.10.7_q7oepo4r57y5enzswpidbbgzsy
+  svelte-preprocess: 4.10.7_besnmoibwkhwtentvwuriss7pa
   svelte-toc: 0.4.0
   svelte2tsx: 0.5.20_besnmoibwkhwtentvwuriss7pa
   tslib: 2.4.0
   typescript: 4.8.4
-  vite: 3.1.8_sass@1.55.0
-  vitest: 0.24.3_jsdom@20.0.1+sass@1.55.0
+  vite: 3.1.8
+  vitest: 0.24.3_jsdom@20.0.1
 
 packages:
 
@@ -214,7 +212,7 @@ packages:
       svelte: 3.52.0
       tiny-glob: 0.2.9
       undici: 5.11.0
-      vite: 3.1.8_sass@1.55.0
+      vite: 3.1.8
     transitivePeerDependencies:
       - diff-match-patch
       - supports-color
@@ -254,7 +252,7 @@ packages:
       magic-string: 0.26.7
       svelte: 3.52.0
       svelte-hmr: 0.15.0_svelte@3.52.0
-      vite: 3.1.8_sass@1.55.0
+      vite: 3.1.8
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1370,10 +1368,6 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /immutable/4.1.0:
-    resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
-    dev: true
-
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -1959,16 +1953,6 @@ packages:
       rimraf: 2.7.1
     dev: true
 
-  /sass/1.55.0:
-    resolution: {integrity: sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    dependencies:
-      chokidar: 3.5.3
-      immutable: 4.1.0
-      source-map-js: 1.0.2
-    dev: true
-
   /saxes/6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -2086,7 +2070,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-check/2.9.2_sass@1.55.0+svelte@3.52.0:
+  /svelte-check/2.9.2_svelte@3.52.0:
     resolution: {integrity: sha512-DRi8HhnCiqiGR2YF9ervPGvtoYrheE09cXieCTEqeTPOTJzfoa54Py8rovIBv4bH4n5HgZYIyTQ3DDLHQLl2uQ==}
     hasBin: true
     peerDependencies:
@@ -2099,7 +2083,7 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.52.0
-      svelte-preprocess: 4.10.7_q7oepo4r57y5enzswpidbbgzsy
+      svelte-preprocess: 4.10.7_besnmoibwkhwtentvwuriss7pa
       typescript: 4.8.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -2127,7 +2111,7 @@ packages:
       svelte: 3.52.0
     dev: true
 
-  /svelte-preprocess/4.10.7_q7oepo4r57y5enzswpidbbgzsy:
+  /svelte-preprocess/4.10.7_besnmoibwkhwtentvwuriss7pa:
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -2172,7 +2156,6 @@ packages:
       '@types/sass': 1.43.1
       detect-indent: 6.1.0
       magic-string: 0.25.9
-      sass: 1.55.0
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.52.0
@@ -2401,7 +2384,7 @@ packages:
       vfile-message: 3.1.2
     dev: true
 
-  /vite/3.1.8_sass@1.55.0:
+  /vite/3.1.8:
     resolution: {integrity: sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -2424,12 +2407,11 @@ packages:
       postcss: 8.4.18
       resolve: 1.22.1
       rollup: 2.78.1
-      sass: 1.55.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.24.3_jsdom@20.0.1+sass@1.55.0:
+  /vitest/0.24.3_jsdom@20.0.1:
     resolution: {integrity: sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -2462,7 +2444,7 @@ packages:
       tinybench: 2.3.0
       tinypool: 0.3.0
       tinyspy: 1.0.2
-      vite: 3.1.8_sass@1.55.0
+      vite: 3.1.8
     transitivePeerDependencies:
       - less
       - sass

--- a/readme.md
+++ b/readme.md
@@ -464,6 +464,7 @@ If you only want to make small adjustments, you can pass the following CSS varia
   - `background: var(--sms-bg)`
   - `color: var(--sms-text-color)`
   - `min-height: var(--sms-min-height, 19pt)`
+  - `width: var(--sms-width)`
   - `max-width: var(--sms-max-width)`
   - `margin: var(--sms-margin)`
   - `font-size: var(--sms-font-size, inherit)`

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -498,160 +498,145 @@
   {/if}
 </div>
 
-<style lang="scss">
-  @mixin default_styles() {
-    & {
-      position: relative;
-      align-items: center;
-      display: flex;
-      cursor: text;
-      border: var(--sms-border, 1pt solid lightgray);
-      border-radius: var(--sms-border-radius, 3pt);
-      background: var(--sms-bg);
-      max-width: var(--sms-max-width);
-      padding: var(--sms-padding, 0 3pt);
-      color: var(--sms-text-color);
-      font-size: var(--sms-font-size, inherit);
-      min-height: var(--sms-min-height, 19pt);
-      margin: var(--sms-margin);
-    }
-    &.open {
-      /* increase z-index when open to ensure the dropdown of one <MultiSelect />
-    displays above that of another slightly below it on the page */
-      z-index: var(--sms-open-z-index, 4);
-    }
-    &:focus-within {
-      border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));
-    }
-    &.disabled {
-      background: var(--sms-disabled-bg, lightgray);
-      cursor: not-allowed;
-    }
-
-    & > ul.selected {
-      display: flex;
-      flex: 1;
-      padding: 0;
-      margin: 0;
-      flex-wrap: wrap;
-    }
-    & > ul.selected > li {
-      align-items: center;
-      border-radius: 3pt;
-      display: flex;
-      margin: 2pt;
-      line-height: normal;
-      transition: 0.3s;
-      white-space: nowrap;
-      background: var(--sms-selected-bg, rgba(0, 0, 0, 0.15));
-      padding: var(--sms-selected-li-padding, 1pt 5pt);
-      color: var(--sms-selected-text-color, var(--sms-text-color));
-    }
-    & button {
-      border-radius: 50%;
-      display: flex;
-      transition: 0.2s;
-      color: inherit;
-      background: transparent;
-      border: none;
-      cursor: pointer;
-      outline: none;
-      padding: 0;
-      margin: 0 0 0 3pt; /* CSS reset */
-    }
-    & button.remove-all {
-      margin: 0 3pt;
-    }
-    ul.selected > li button:hover,
-    button.remove-all:hover,
-    button:focus {
-      color: var(--sms-remove-btn-hover-color, lightskyblue);
-      background: var(--sms-remove-btn-hover-bg, rgba(0, 0, 0, 0.2));
-    }
-
-    & input {
-      margin: auto 0; /* CSS reset */
-      padding: 0; /* CSS reset */
-    }
-    & > ul.selected > li > input {
-      border: none;
-      outline: none;
-      background: none;
-      flex: 1; /* this + next line fix issue #12 https://git.io/JiDe3 */
-      min-width: 2em;
-      /* ensure input uses text color and not --sms-selected-text-color */
-      color: var(--sms-text-color);
-      font-size: inherit;
-      cursor: inherit; /* needed for disabled state */
-      border-radius: 0; /* reset ul.selected > li */
-    }
-    & > ul.selected > li > input::placeholder {
-      padding-left: 5pt;
-      color: var(--sms-placeholder-color);
-      opacity: var(--sms-placeholder-opacity);
-    }
-    & > input.form-control {
-      width: 2em;
-      position: absolute;
-      background: transparent;
-      border: none;
-      outline: none;
-      z-index: -1;
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    & > ul.options {
-      list-style: none;
-      padding: 4pt 0;
-      top: 100%;
-      left: 0;
-      width: 100%;
-      position: absolute;
-      border-radius: 1ex;
-      overflow: auto;
-      background: var(--sms-options-bg, white);
-      max-height: var(--sms-options-max-height, 50vh);
-      overscroll-behavior: var(--sms-options-overscroll, none);
-      box-shadow: var(--sms-options-shadow, 0 0 14pt -8pt black);
-      transition: all 0.2s;
-    }
-    & > ul.options.hidden {
-      visibility: hidden;
-      opacity: 0;
-      transform: translateY(50px);
-    }
-    & > ul.options > li {
-      padding: 3pt 2ex;
-      cursor: pointer;
-      scroll-margin: var(--sms-options-scroll-margin, 100px);
-    }
-    & > ul.options span {
-      // for noMatchingOptionsMsg
-      padding: 3pt 2ex;
-    }
-    & > ul.options > li.selected {
-      background: var(--sms-li-selected-bg);
-      color: var(--sms-li-selected-color);
-    }
-    & > ul.options > li.active {
-      background: var(--sms-li-active-bg, var(--sms-active-color, rgba(0, 0, 0, 0.15)));
-    }
-    & > ul.options > li.disabled {
-      cursor: not-allowed;
-      background: var(--sms-li-disabled-bg, #f5f5f6);
-      color: var(--sms-li-disabled-text, #b8b8b8);
-    }
-  }
-
+<style>
   :where(div.multiselect) {
-    @include default_styles();
+    position: relative;
+    align-items: center;
+    display: flex;
+    cursor: text;
+    border: var(--sms-border, 1pt solid lightgray);
+    border-radius: var(--sms-border-radius, 3pt);
+    background: var(--sms-bg);
+    max-width: var(--sms-max-width);
+    padding: var(--sms-padding, 0 3pt);
+    color: var(--sms-text-color);
+    font-size: var(--sms-font-size, inherit);
+    min-height: var(--sms-min-height, 19pt);
+    margin: var(--sms-margin);
+  }
+  :where(div.multiselect.open) {
+    /* increase z-index when open to ensure the dropdown of one <MultiSelect />
+    displays above that of another slightly below it on the page */
+    z-index: var(--sms-open-z-index, 4);
+  }
+  :where(div.multiselect:focus-within) {
+    border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));
+  }
+  :where(div.multiselect.disabled) {
+    background: var(--sms-disabled-bg, lightgray);
+    cursor: not-allowed;
   }
 
-  // https://github.com/janosh/svelte-multiselect/issues/117
-  @supports not selector(:where(div.multiselect)) {
-    div.multiselect {
-      @include default_styles();
-    }
+  :where(div.multiselect > ul.selected) {
+    display: flex;
+    flex: 1;
+    padding: 0;
+    margin: 0;
+    flex-wrap: wrap;
+  }
+  :where(div.multiselect > ul.selected > li) {
+    align-items: center;
+    border-radius: 3pt;
+    display: flex;
+    margin: 2pt;
+    line-height: normal;
+    transition: 0.3s;
+    white-space: nowrap;
+    background: var(--sms-selected-bg, rgba(0, 0, 0, 0.15));
+    padding: var(--sms-selected-li-padding, 1pt 5pt);
+    color: var(--sms-selected-text-color, var(--sms-text-color));
+  }
+  :where(div.multiselect button) {
+    border-radius: 50%;
+    display: flex;
+    transition: 0.2s;
+    color: inherit;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    padding: 0;
+    margin: 0 0 0 3pt; /* CSS reset */
+  }
+  :where(div.multiselect button.remove-all) {
+    margin: 0 3pt;
+  }
+  :where(ul.selected > li button:hover, button.remove-all:hover, button:focus) {
+    color: var(--sms-remove-btn-hover-color, lightskyblue);
+    background: var(--sms-remove-btn-hover-bg, rgba(0, 0, 0, 0.2));
+  }
+
+  :where(div.multiselect input) {
+    margin: auto 0; /* CSS reset */
+    padding: 0; /* CSS reset */
+  }
+  :where(div.multiselect > ul.selected > li > input) {
+    border: none;
+    outline: none;
+    background: none;
+    flex: 1; /* this + next line fix issue #12 https://git.io/JiDe3 */
+    min-width: 2em;
+    /* ensure input uses text color and not --sms-selected-text-color */
+    color: var(--sms-text-color);
+    font-size: inherit;
+    cursor: inherit; /* needed for disabled state */
+    border-radius: 0; /* reset ul.selected > li */
+  }
+  :where(div.multiselect > ul.selected > li > input::placeholder) {
+    padding-left: 5pt;
+    color: var(--sms-placeholder-color);
+    opacity: var(--sms-placeholder-opacity);
+  }
+  :where(div.multiselect > input.form-control) {
+    width: 2em;
+    position: absolute;
+    background: transparent;
+    border: none;
+    outline: none;
+    z-index: -1;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  :where(div.multiselect > ul.options) {
+    list-style: none;
+    padding: 4pt 0;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    position: absolute;
+    border-radius: 1ex;
+    overflow: auto;
+    background: var(--sms-options-bg, white);
+    max-height: var(--sms-options-max-height, 50vh);
+    overscroll-behavior: var(--sms-options-overscroll, none);
+    box-shadow: var(--sms-options-shadow, 0 0 14pt -8pt black);
+    transition: all 0.2s;
+  }
+  :where(div.multiselect > ul.options.hidden) {
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(50px);
+  }
+  :where(div.multiselect > ul.options > li) {
+    padding: 3pt 2ex;
+    cursor: pointer;
+    scroll-margin: var(--sms-options-scroll-margin, 100px);
+  }
+  /* for noOptionsMsg */
+  :where(div.multiselect > ul.options span) {
+    padding: 3pt 2ex;
+  }
+  :where(div.multiselect > ul.options > li.selected) {
+    background: var(--sms-li-selected-bg);
+    color: var(--sms-li-selected-color);
+  }
+  :where(div.multiselect > ul.options > li.active) {
+    background: var(--sms-li-active-bg, var(--sms-active-color, rgba(0, 0, 0, 0.15)));
+  }
+  :where(div.multiselect > ul.options > li.disabled) {
+    cursor: not-allowed;
+    background: var(--sms-li-disabled-bg, #f5f5f6);
+    color: var(--sms-li-disabled-text, #b8b8b8);
   }
 </style>

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -504,9 +504,11 @@
     align-items: center;
     display: flex;
     cursor: text;
+    box-sizing: border-box;
     border: var(--sms-border, 1pt solid lightgray);
     border-radius: var(--sms-border-radius, 3pt);
     background: var(--sms-bg);
+    width: var(--sms-width);
     max-width: var(--sms-max-width);
     padding: var(--sms-padding, 0 3pt);
     color: var(--sms-text-color);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,7 +26,7 @@ export default {
   extensions: [`.svelte`, `.svx`, `.md`],
 
   preprocess: [
-    preprocess({ sass: false, scss: true }),
+    preprocess(),
     mdsvex({ rehypePlugins, extensions: [`.svx`, `.md`] }),
   ],
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ const vite_config: UserConfig & { test: VitestConfig } = {
 
   test: {
     environment: `jsdom`,
+    css: true,
   },
 
   resolve: {
@@ -15,6 +16,7 @@ const vite_config: UserConfig & { test: VitestConfig } = {
       $src: resolve(`./src`),
     },
   },
+
   server: {
     fs: { allow: [`..`] }, // needed to import readme.md
     port: 3000,


### PR DESCRIPTION
Closes #140.

SCSS preprocessing leads to increased specificity making default CSS difficult to override. `:where()` is the future i.t.o. 0-specificity default component styles with [growing browser support](https://github.com/sveltejs/svelte/issues/4374#issuecomment-1290959427). Svelte v4 might even make it the default to wrap component styles in `:where()` (see https://github.com/sveltejs/svelte/issues/4374).