### PR TITLE
Don't `console.error` about missing `options` if `disabled=true`

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -76,7 +76,7 @@
   type $$Events = MultiSelectEvents // for type-safe event listening on this component
 
   if (!(options?.length > 0)) {
-    if (allowUserOptions || loading) {
+    if (allowUserOptions || loading || disabled) {
       options = [] // initializing as array avoids errors when component mounts
     } else {
       // only error for empty options if user is not allowed to create custom

--- a/tests/unit/multiselect.test.ts
+++ b/tests/unit/multiselect.test.ts
@@ -684,31 +684,29 @@ test.each([
   }
 )
 
-test(`console error if no options are provided`, () => {
-  console.error = vi.fn()
-  new MultiSelect({
-    target: document.body,
-    props: { options: [] },
-  })
+test.each([
+  [true, false, 0],
+  [false, true, 0],
+  [true, true, 0],
+  [false, false, 1],
+])(
+  `no console error about missing options if loading or disabled=true`,
+  (loading, disabled, expected) => {
+    console.error = vi.fn()
 
-  expect(console.error).toHaveBeenCalledOnce()
+    new MultiSelect({
+      target: document.body,
+      props: { options: [], loading, disabled },
+    })
 
-  // check error message is as expected
-  expect(console.error.mock.calls[0][0]).toContain(
-    `MultiSelect received no options`
-  )
-})
-
-test(`no console error about missing options if loading=true`, () => {
-  console.error = vi.fn()
-
-  new MultiSelect({
-    target: document.body,
-    props: { options: [], loading: true },
-  })
-
-  expect(console.error).not.toHaveBeenCalled()
-})
+    expect(console.error).toHaveBeenCalledTimes(expected)
+    if (expected > 0) {
+      expect(console.error.mock.calls[0][0]).toContain(
+        `MultiSelect received no options`
+      )
+    }
+  }
+)
 
 test.each([[null], [`custom add option message`]])(
   `arrow keys on empty multiselect toggle addOptionMsg as active`,


### PR DESCRIPTION
As mentioned in this comment: https://github.com/janosh/svelte-multiselect/issues/154#issuecomment-1315607440