### PR TITLE
Form validation docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Build package and publish to NPM
         if: github.event_name == 'release' && steps.tests.outcome == 'success' && runner.os == 'Linux'
         run: |
-          pnpm package
-          pnpm publish package --no-git-check
+          npm run package
+          npm publish ./package
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/components/CollapsibleCode.svelte
+++ b/src/components/CollapsibleCode.svelte
@@ -3,13 +3,15 @@
   import hljs from 'highlight.js/lib/common'
   import 'highlight.js/styles/vs2015.css'
   import { tweened } from 'svelte/motion'
-  import { slide } from 'svelte/transition'
   import CopyButton from './CopyButton.svelte'
 
   export let duration: number = 200
   export let open: boolean = false
   export let code: string
   export let repl_url: string = ``
+  export let github_url: string = ``
+  export let style: string | null = null
+  export let language = `html`
 
   const angle = tweened(180, { duration })
 
@@ -19,7 +21,8 @@
   }
 </script>
 
-<nav>
+<nav {style}>
+  <slot name="title" />
   <button on:click={toggle}>
     <span style="display: inline-block; transform: rotate({$angle}deg);">👆</span>
     {open ? `Close` : `View code`}
@@ -31,21 +34,27 @@
       REPL
     </a>
   {/if}
+
+  {#if github_url}
+    <a href={github_url} target="_blank" rel="noreferrer">
+      <Icon icon="octicon:mark-github-16" inline />
+      GitHub
+    </a>
+  {/if}
 </nav>
 
 <div class:open>
   <aside>
     <CopyButton content={code} />
   </aside>
-  <pre><code>{@html hljs.highlight(code.trim(), { language: `html` }).value}</code></pre>
+  <pre><code>{@html hljs.highlight(code.trim(), { language }).value}</code></pre>
 </div>
 
 <style>
   nav {
-    position: absolute;
     top: 8pt;
     right: 1em;
-    display: flex;
+    display: inline-flex;
     gap: 1ex;
     line-height: 1;
   }
@@ -70,7 +79,7 @@
   div.open {
     visibility: visible;
     opacity: 1;
-    max-height: 100vh;
+    max-height: 9999vh;
   }
   aside {
     position: absolute;

--- a/src/components/CollapsibleCode.svelte
+++ b/src/components/CollapsibleCode.svelte
@@ -37,8 +37,8 @@
 
   {#if github_url}
     <a href={github_url} target="_blank" rel="noreferrer">
-      <Icon icon="octicon:mark-github-16" inline />
-      GitHub
+      <Icon icon="octicon:mark-github" inline />
+      &nbsp;GitHub
     </a>
   {/if}
 </nav>

--- a/src/components/ColorSlot.svelte
+++ b/src/components/ColorSlot.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   export let option: string
-  export let idx: number
+  export let idx: number | null = null
+  export let style: string | null = null
 </script>
 
-<div>
-  {idx + 1}
+<div {style}>
+  {#if idx !== null}{idx + 1}{/if}
   {#if typeof CSS !== `undefined` && CSS.supports(`color`, option)}
     <span style:background={option} />
   {/if}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,8 +1,9 @@
 export const prerender = true
 
-export const demo_routes = Object.keys(import.meta.glob(`./**/*.svx`)).map(
-  (filename) => filename.split(`.`)[1].replace(`/+page`, ``)
-)
+export const demo_routes = Object.keys(
+  import.meta.glob(`./*/+page.{svx,svelte}`)
+).map((filename) => filename.split(`.`)[1].replace(`/+page`, ``))
+
 if (demo_routes.length < 5) {
   throw new Error(`Too few demo routes found: ${demo_routes.length}`)
 }

--- a/src/routes/form/+page.svx
+++ b/src/routes/form/+page.svx
@@ -1,16 +1,17 @@
-<script>
+<script lang="ts">
   import MultiSelect from '$lib'
   import ColorSlot from '$src/components/ColorSlot.svelte'
   import { colors } from '$src/options'
 
-  async function handle_submit(event) {
+  async function handle_submit(event: SubmitEvent) {
     // use bind:this={form} or event.target as arg to new FormData()
-    form_data = new FormData(event.target)
+    form_data = new FormData(event.target as HTMLFormElement)
   }
-  let form_data
-  let form
-  const name="martian-flag"
+  let form_data: FormData
+  const name = `martian-flag`
 </script>
+
+This example shows the JavaScript way of handling MultiSelect fields in form submission events. If you're using SvelteKit, you may want to look at check out [this example](/kit-form-actions) on to use [form actions](https://kit.svelte.dev/docs/form-actions) instead which work even with JS disabled.
 
 <form on:submit|preventDefault={handle_submit}>
   <label for="colors">
@@ -27,10 +28,14 @@
     <ColorSlot let:idx {idx} let:option {option} slot="option" />
   </MultiSelect>
   <button>Submit</button>
-  <small>select some options, then click submit to see what data MultiSelect sends to a form submit handler</small>
+  <small
+    >select some options, then click submit to see what data MultiSelect sends to a form
+    submit handler</small
+  >
 </form>
 
-> Hint: Use <code>JSON.parse()</code> to convert the string value passed to form submit handler back to array.
+> Hint: Use<code>JSON.parse()</code> to convert the string value passed to form submit
+handler back to array.
 
 {#if form_data}
   Received form data:

--- a/src/routes/kit-form-actions/+page.server.ts
+++ b/src/routes/kit-form-actions/+page.server.ts
@@ -2,7 +2,9 @@ import { invalid } from '@sveltejs/kit'
 import { readFileSync } from 'fs'
 import type { Actions, PageServerLoad } from './$types'
 
-export const actions: Actions = {
+// remove leading underscore to activate this example
+// needs to be disabled for building static site
+export const _actions: Actions = {
   'validate-form': async ({ request }) => {
     const data = await request.formData()
     let colors = data.get(`colors`)
@@ -24,15 +26,16 @@ export const actions: Actions = {
   },
 }
 
-export const prerender = false
-
 export const load: PageServerLoad = () => {
   return {
     codes: [`.svelte`, `.server.ts`].map((ext) => {
       const filepath = new URL(`./+page${ext}`, import.meta.url)
-      const code = readFileSync(filepath, `utf8`)
-
-      return [`+page${ext}`, code]
+      try {
+        const code = readFileSync(filepath, `utf8`)
+        return [`+page${ext}`, code]
+      } catch (error) {
+        return [`+page${ext}`, `code`]
+      }
     }),
   }
 }

--- a/src/routes/kit-form-actions/+page.server.ts
+++ b/src/routes/kit-form-actions/+page.server.ts
@@ -1,0 +1,38 @@
+import { invalid } from '@sveltejs/kit'
+import { readFileSync } from 'fs'
+import type { Actions, PageServerLoad } from './$types'
+
+export const actions: Actions = {
+  'validate-form': async ({ request }) => {
+    const data = await request.formData()
+    let colors = data.get(`colors`)
+
+    try {
+      colors = JSON.parse(colors)
+    } catch (err) {
+      return invalid(400, { colors, error: `json` })
+    }
+
+    if (!Array.isArray(colors)) {
+      return invalid(400, { colors, error: `array` })
+    }
+    if (colors.length === 1 && colors[0] === `Red`) {
+      return invalid(400, { colors, error: `boring` })
+    }
+
+    return { colors, success: true }
+  },
+}
+
+export const prerender = false
+
+export const load: PageServerLoad = () => {
+  return {
+    codes: [`.svelte`, `.server.ts`].map((ext) => {
+      const filepath = new URL(`./+page${ext}`, import.meta.url)
+      const code = readFileSync(filepath, `utf8`)
+
+      return [`+page${ext}`, code]
+    }),
+  }
+}

--- a/src/routes/kit-form-actions/+page.svelte
+++ b/src/routes/kit-form-actions/+page.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import MultiSelect from '$lib'
+  import ColorSlot from '$src/components/ColorSlot.svelte'
+  import { colors } from '$src/options'
+  import CollapsibleCode from '$src/components/CollapsibleCode.svelte'
+  import type { ActionData, PageData } from './$types'
+  import { repository } from '../../../package.json'
+  import { page } from '$app/stores'
+
+  export let form: ActionData
+  export let data: PageData
+
+  $: err_msg = {
+    json: `The email field is required`,
+    array: `The email field is required`,
+    boring: `Boring answer!`,
+  }[form?.error as string]
+</script>
+
+<p>
+  This example shows the SvelteKit form action way of handling MultiSelect fields in form
+  submission events. If you're not interested in
+  <a href="https://kit.svelte.dev/docs/form-actions#progressive-enhancement">
+    progressively enhanced forms
+  </a>
+  (i.e. supporting no-JS browsers) take a look at the
+  <a href="/form">JS form example</a>
+  instead.
+</p>
+
+<form method="POST" action="?/validate-form">
+  <label for="colors">
+    <strong>Which colors would you pick for the Martian flag?</strong>
+  </label>
+  <MultiSelect
+    id="colors"
+    options={colors}
+    placeholder="Pick some colors..."
+    name="colors"
+    required
+    invalid={!!form?.error}
+    selected={form?.colors ?? [`Red`]}
+  >
+    <ColorSlot let:idx {idx} let:option {option} slot="selected" />
+    <ColorSlot let:idx {idx} let:option {option} slot="option" />
+  </MultiSelect>
+  <button>Submit</button>
+  <small>
+    select some options, then click submit to see what data MultiSelect sends to a form
+    submit handler
+  </small>
+  {#if err_msg}
+    <p class="error">{err_msg}</p>
+  {/if}
+  {#if form?.success}
+    <p class="success">
+      Good answer! You entered
+      {#each form.colors as color}
+        <ColorSlot
+          option={color}
+          style="display: inline-flex; vertical-align: middle; margin: 0 0 0 1ex;"
+        />
+      {/each}
+    </p>
+  {/if}
+</form>
+
+{#each data.codes as [title, code]}
+  {@const filepath = new URL(import.meta.url).pathname.replace(/\+page.+/, title)}
+  <section>
+    <strong>{title}</strong>
+    <CollapsibleCode
+      {code}
+      language={title.endsWith(`.ts`) ? `typescript` : `html`}
+      github_url="{repository}/blob/main{filepath}"
+    />
+  </section>
+{/each}
+
+<style>
+  form {
+    background-color: rgba(255, 255, 255, 0.1);
+    padding: 1ex 1em;
+    border-radius: 3pt;
+  }
+  p {
+    margin: 1em 0 1ex;
+  }
+  p.error {
+    color: red;
+  }
+  p.success {
+    width: max-content;
+    padding: 1pt 6pt;
+    box-sizing: border-box;
+    color: lightgreen;
+    border: 1px solid;
+    border-radius: 3pt;
+  }
+  section {
+    position: relative;
+    margin: 1em 0;
+    background-color: rgba(0, 255, 255, 0.1);
+    padding: 1ex 1em;
+    border-radius: 3pt;
+  }
+  section strong {
+    padding: 0 6pt 0 0;
+  }
+</style>

--- a/src/routes/kit-form-actions/+page.svelte
+++ b/src/routes/kit-form-actions/+page.svelte
@@ -3,12 +3,11 @@
   import ColorSlot from '$src/components/ColorSlot.svelte'
   import { colors } from '$src/options'
   import CollapsibleCode from '$src/components/CollapsibleCode.svelte'
-  import type { ActionData, PageData } from './$types'
+  import type { ActionData, PageServerData } from './$types'
   import { repository } from '../../../package.json'
-  import { page } from '$app/stores'
 
   export let form: ActionData
-  export let data: PageData
+  export let data: PageServerData
 
   $: err_msg = {
     json: `The email field is required`,
@@ -27,6 +26,12 @@
   <a href="/form">JS form example</a>
   instead.
 </p>
+
+<blockquote>
+  Note that this example will only work when running the dev server locally since it needs
+  a server to respond to the form's POST request and this documentation site only serves
+  static HTML.
+</blockquote>
 
 <form method="POST" action="?/validate-form">
   <label for="colors">

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -27,5 +27,5 @@ function session_store<T>(name: string, initialValue: T) {
 
 export const language_store = session_store<string[]>(
   `language-store`,
-  `Python TypeScript C`.split(` `)
+  `Python TypeScript C Rust`.split(` `)
 )

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -22,6 +22,7 @@ const rehypePlugins = [
   ],
 ]
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
   extensions: [`.svelte`, `.svx`, `.md`],
 

--- a/tests/unit/multiselect.test.ts
+++ b/tests/unit/multiselect.test.ts
@@ -736,3 +736,30 @@ test(`disabled multiselect has disabled icon`, () => {
     doc_query(`ul.selected + svg[data-name='disabled-icon']`)
   ).toBeInstanceOf(SVGSVGElement)
 })
+
+test(`can remove user-created selected option which is not in dropdown list`, async () => {
+  // i.e. allowUserOptions=true, not 'append', meaning user options are only selected but
+  // aren't added to dropdown list yet remove() should still be able to delete them
+  new MultiSelect({
+    target: document.body,
+    props: { options: [`1`, `2`, `3`], allowUserOptions: true },
+  })
+
+  // add a new option created from user text input
+  const input = doc_query(`ul.selected input`)
+  input.value = `foo`
+  input.dispatchEvent(new InputEvent(`input`))
+  await sleep()
+
+  const li = doc_query(`ul.options li[title='Create this option...']`)
+  li.dispatchEvent(new MouseEvent(`mouseup`))
+  await sleep()
+  expect(doc_query(`ul.selected`).textContent?.trim()).toBe(`foo`)
+
+  // remove the new option
+  const li_selected = doc_query(`ul.selected li button[title*='Remove']`)
+  li_selected.dispatchEvent(new MouseEvent(`mouseup`))
+  await sleep()
+
+  expect(doc_query(`ul.selected`).textContent?.trim()).toBe(``)
+})


### PR DESCRIPTION
Closes #23.

Add a new example `/kit-form-actions` that shows how to do hook up MultiSelect to a [SvelteKit form action](https://kit.svelte.dev/docs/form-actions) and how to surface [validation errors](https://kit.svelte.dev/docs/form-actions#anatomy-of-an-action-validation-errors) that work even with JS disabled (which of course MultiSelect doesn't support).