### PR TITLE
Set `<base href="/svelte-multiselect" />` in CI deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,10 @@
 name: Docs
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
+  # GH pages doesn't support PR previews yet but plans to add
+  # https://github.com/community/community/discussions/7730#discussioncomment-1885967
   workflow_dispatch:
 
 # set permissions of GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,13 +13,8 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: true # allow one concurrent deployment
-
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -37,16 +32,17 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
-          pnpm build
+        run: pnpm install
 
-      - uses: actions/upload-pages-artifact@v1
+      - name: Build site
+        run: pnpm build
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v1
         with:
           path: build
 
   deploy:
-    name: Deploy
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/src/app.html
+++ b/src/app.html
@@ -16,15 +16,15 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
     <meta property="og:type" content="article" />
-    <meta property="og:image" content="/favicon.svg" />
+    <meta property="og:image" content="favicon.svg" />
     <meta
       property="og:url"
       content="https://janosh.github.io/svelte-multiselect"
     />
     <meta property="twitter:site_name" content="Svelte MultiSelect" />
 
-    <link rel="icon" href="/favicon.svg" />
-    <link rel="stylesheet" href="/prism-vsc-dark-plus.css" />
+    <link rel="icon" href="favicon.svg" />
+    <link rel="stylesheet" href="prism-vsc-dark-plus.css" />
 
     %sveltekit.head%
   </head>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -22,7 +22,7 @@
     {/if}
   {/if}
   <p>
-    Return to <a href="/">index page</a>.
+    Return to <a href=".">index page</a>.
   </p>
 
   {#if dev && $page.error?.stack}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,9 +19,9 @@
 <GitHubCorner href={repository} />
 
 {#if demo_routes.some((route) => $page.url.pathname.endsWith(route))}
-  <a href="/" aria-label="Back to index page">&laquo; back</a>
+  <a href="." aria-label="Back to index page">&laquo; back</a>
   <h1>
-    <img src="/favicon.svg" alt="Svelte MultiSelect" height="50" width="50" />&ensp;Svelte
+    <img src="favicon.svg" alt="Svelte MultiSelect" height="50" width="50" />&ensp;Svelte
     MultiSelect Examples
   </h1>
 
@@ -47,7 +47,7 @@
     place-content: center;
     place-items: center;
   }
-  a[href='/'] {
+  a[href='.'] {
     font-size: 16pt;
     position: absolute;
     top: 2em;
@@ -57,7 +57,7 @@
     border-radius: 3pt;
     transition: 0.2s;
   }
-  a[href='/']:hover {
+  a[href='.']:hover {
     background-color: rgba(255, 255, 255, 0.2);
   }
   nav {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,8 @@
   import GitHubCorner from 'svelte-github-corner'
   import '../app.css'
   import { demo_routes } from './+layout'
+  import { name, repository } from '../../package.json'
+  import { dev, browser } from '$app/environment'
 
   $: is_current = (path: string) => {
     if (path === $page.url.pathname) return `page`
@@ -11,7 +13,11 @@
   }
 </script>
 
-<GitHubCorner href="https://github.com/janosh/svelte-multiselect" />
+<svelte:head>
+  <base href="/{browser && !dev ? name : ''}" />
+</svelte:head>
+
+<GitHubCorner href={repository} />
 
 {#if demo_routes.includes($page.url.pathname)}
   <a href="/" aria-label="Back to index page">&laquo; back</a>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,7 +18,7 @@
 
 <GitHubCorner href={repository} />
 
-{#if demo_routes.includes($page.url.pathname)}
+{#if demo_routes.some((route) => $page.url.pathname.endsWith(route))}
   <a href="/" aria-label="Back to index page">&laquo; back</a>
   <h1>
     <img src="/favicon.svg" alt="Svelte MultiSelect" height="50" width="50" />&ensp;Svelte

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,6 @@
   import '../app.css'
   import { demo_routes } from './+layout'
   import { name, repository } from '../../package.json'
-  import { dev, browser } from '$app/environment'
 
   $: is_current = (path: string) => {
     if (path === $page.url.pathname) return `page`
@@ -14,7 +13,7 @@
 </script>
 
 <svelte:head>
-  <base href="/{browser && !dev ? name : ''}" />
+  <base href={import.meta.env.CI ? `/${name}/` : ``} />
 </svelte:head>
 
 <GitHubCorner href={repository} />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -2,7 +2,7 @@ export const prerender = true
 
 export const demo_routes = Object.keys(
   import.meta.glob(`./*/+page.{svx,svelte}`)
-).map((filename) => filename.split(`.`)[1].replace(`/+page`, ``))
+).map((filename) => filename.split(`/`)[1])
 
 if (demo_routes.length < 5) {
   throw new Error(`Too few demo routes found: ${demo_routes.length}`)

--- a/src/routes/kit-form-actions/+page.svelte
+++ b/src/routes/kit-form-actions/+page.svelte
@@ -23,7 +23,7 @@
     progressively enhanced forms
   </a>
   (i.e. supporting no-JS browsers) take a look at the
-  <a href="/form">JS form example</a>
+  <a href="form">JS form example</a>
   instead.
 </p>
 


### PR DESCRIPTION
Needed to fix page navigation in GH pages deployment being served at `https://janosh.github.io/svelte-multiselect` but internal links pointing to `https://janosh.github.io`