### PR TITLE
feat: add type inference for the `options` prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -441,21 +441,8 @@ The above list of events are [Svelte `dispatch` events](https://svelte.dev/tutor
 
 ## 🦺 &nbsp; TypeScript
 
-TypeScript users can import the types used for internal type safety:
-
-```svelte
-<script lang="ts">
-  import MultiSelect from 'svelte-multiselect'
-  import type { Option, ObjectOption } from 'svelte-multiselect'
-
-  const myOptions: ObjectOption[] = [
-    { label: 'foo', value: 42 },
-    { label: 'bar', value: 69 },
-  ]
-  // an Option can be string | number | ObjectOption
-  const myNumbers: Option[] = [42, 69]
-</script>
-```
+The type of the `options` prop will be automatically inferred and type-safety
+will be enforced for all related props (e.g. `selected`).
 
 ## ✨ &nbsp; Styling
 

--- a/readme.md
+++ b/readme.md
@@ -441,8 +441,32 @@ The above list of events are [Svelte `dispatch` events](https://svelte.dev/tutor
 
 ## 🦺 &nbsp; TypeScript
 
-The type of the `options` prop will be automatically inferred and type-safety
-will be enforced for all related props (e.g. `selected`).
+The type of `options` is inferred automatically from the data you pass. E.g.
+
+```ts
+const options = [
+   { label: `foo`, value: 42 }
+   { label: `bar`, value: 69 }
+]
+// type Option = { label: string, value: number }
+const options = [`foo`, `bar`]
+// type Option = string
+const options = [42, 69]
+// type Option = number
+```
+
+The inferred type of `Option` is used to enforce type-safety on derived props like `selected` as well as slot components. E.g. you'll get an error when trying to use a slot component that expects a string if your options are objects (see [this comment](https://github.com/janosh/svelte-multiselect/pull/189/files#r1058853697) for example screenshots).
+
+You can also import [the types this component uses](https://github.com/janosh/svelte-multiselect/blob/main/src/lib/index.ts) for downstream applications:
+
+```ts
+import {
+  Option,
+  ObjectOption,
+  DispatchEvents,
+  MultiSelectEvents,
+} from 'svelte-multiselect'
+```
 
 ## ✨ &nbsp; Styling
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { createEventDispatcher, tick } from 'svelte'
   import { flip } from 'svelte/animate'
-  import type { DispatchEvents, MultiSelectEvents, ObjectOption, Option as GenericOption } from './'
+  import type {
+    DispatchEvents,
+    MultiSelectEvents,
+    ObjectOption,
+    Option as GenericOption,
+  } from './'
   import CircleSpinner from './CircleSpinner.svelte'
   import { CrossIcon, DisabledIcon, ExpandIcon } from './icons'
   import Wiggle from './Wiggle.svelte'

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
   import { createEventDispatcher, tick } from 'svelte'
   import { flip } from 'svelte/animate'
-  import type {
-    DispatchEvents,
-    MultiSelectEvents,
-    ObjectOption,
-    Option as GenericOption,
-  } from './'
+  import type { DispatchEvents, MultiSelectEvents, Option as GenericOption } from './'
   import CircleSpinner from './CircleSpinner.svelte'
   import { CrossIcon, DisabledIcon, ExpandIcon } from './icons'
   import Wiggle from './Wiggle.svelte'
-
   type Option = $$Generic<GenericOption>
 
   export let activeIndex: number | null = null
@@ -67,7 +61,7 @@
   export let searchText: string = ``
   export let selected: Option[] =
     options
-      ?.filter((op) => (op as ObjectOption)?.preselected)
+      ?.filter((op) => op instanceof Object && op?.preselected)
       .slice(0, maxSelect ?? undefined) ?? []
   export let sortSelected: boolean | ((op1: Option, op2: Option) => number) = false
   export let selectedOptionsDraggable: boolean = !sortSelected
@@ -76,7 +70,7 @@
   export let value: Option | Option[] | null = null
 
   // get the label key from an option object or the option itself if it's a string or number
-  const get_label = (op: Option) => (op instanceof Object ? op.label : op)
+  const get_label = (op: GenericOption) => (op instanceof Object ? op.label : op)
 
   // if maxSelect=1, value is the single item in selected (or null if selected is empty)
   // this solves both https://github.com/janosh/svelte-multiselect/issues/86 and

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -6,7 +6,7 @@
   import { CrossIcon, DisabledIcon, ExpandIcon } from './icons'
   import Wiggle from './Wiggle.svelte'
 
-  type InferredOption = $$Generic<Option>;
+  type InferredOption = $$Generic<Option>
 
   export let activeIndex: number | null = null
   export let activeOption: InferredOption | null = null
@@ -19,8 +19,10 @@
   export let disabled: boolean = false
   export let disabledInputTitle: string = `This input is disabled`
   // case-insensitive equality comparison after string coercion (looking only at the `label` key of object options)
-  export let duplicateFunc: (op1: InferredOption, op2: InferredOption) => boolean = (op1, op2) =>
-    `${get_label(op1)}`.toLowerCase() === `${get_label(op2)}`.toLowerCase()
+  export let duplicateFunc: (op1: InferredOption, op2: InferredOption) => boolean = (
+    op1,
+    op2
+  ) => `${get_label(op1)}`.toLowerCase() === `${get_label(op2)}`.toLowerCase()
   export let duplicateOptionMsg: string = `This option is already selected`
   export let duplicates: boolean = false // whether to allow duplicate options
   export let filterFunc = (op: InferredOption, searchText: string): boolean => {
@@ -64,7 +66,9 @@
     options
       ?.filter((op) => (op as ObjectOption)?.preselected)
       .slice(0, maxSelect ?? undefined) ?? []
-  export let sortSelected: boolean | ((op1: InferredOption, op2: InferredOption) => number) = false
+  export let sortSelected:
+    | boolean
+    | ((op1: InferredOption, op2: InferredOption) => number) = false
   export let selectedOptionsDraggable: boolean = !sortSelected
   export let ulOptionsClass: string = ``
   export let ulSelectedClass: string = ``

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import { createEventDispatcher, tick } from 'svelte'
   import { flip } from 'svelte/animate'
-  import type { DispatchEvents, MultiSelectEvents, ObjectOption, Option } from './'
+  import type { DispatchEvents, MultiSelectEvents, ObjectOption, Option as GenericOption } from './'
   import CircleSpinner from './CircleSpinner.svelte'
   import { CrossIcon, DisabledIcon, ExpandIcon } from './icons'
   import Wiggle from './Wiggle.svelte'
 
-  type InferredOption = $$Generic<Option>
+  type Option = $$Generic<GenericOption>
 
   export let activeIndex: number | null = null
-  export let activeOption: InferredOption | null = null
+  export let activeOption: Option | null = null
   export let addOptionMsg: string = `Create this option...`
   export let allowUserOptions: boolean | 'append' = false
   export let autocomplete: string = `off`
@@ -19,13 +19,11 @@
   export let disabled: boolean = false
   export let disabledInputTitle: string = `This input is disabled`
   // case-insensitive equality comparison after string coercion (looking only at the `label` key of object options)
-  export let duplicateFunc: (op1: InferredOption, op2: InferredOption) => boolean = (
-    op1,
-    op2
-  ) => `${get_label(op1)}`.toLowerCase() === `${get_label(op2)}`.toLowerCase()
+  export let duplicateFunc: (op1: Option, op2: Option) => boolean = (op1, op2) =>
+    `${get_label(op1)}`.toLowerCase() === `${get_label(op2)}`.toLowerCase()
   export let duplicateOptionMsg: string = `This option is already selected`
   export let duplicates: boolean = false // whether to allow duplicate options
-  export let filterFunc = (op: InferredOption, searchText: string): boolean => {
+  export let filterFunc = (op: Option, searchText: string): boolean => {
     if (!searchText) return true
     return `${get_label(op)}`.toLowerCase().includes(searchText.toLowerCase())
   }
@@ -40,7 +38,7 @@
   export let liOptionClass: string = ``
   export let liSelectedClass: string = ``
   export let loading: boolean = false
-  export let matchingOptions: InferredOption[] = []
+  export let matchingOptions: Option[] = []
   export let maxSelect: number | null = null // null means there is no upper limit for selected.length
   export let maxSelectMsg: ((current: number, max: number) => string) | null = (
     current: number,
@@ -50,7 +48,7 @@
   export let name: string | null = null
   export let noMatchingOptionsMsg: string = `No matching options`
   export let open: boolean = false
-  export let options: InferredOption[]
+  export let options: Option[]
   export let outerDiv: HTMLDivElement | null = null
   export let outerDivClass: string = ``
   export let parseLabelsAsHtml: boolean = false // should not be combined with allowUserOptions!
@@ -62,20 +60,18 @@
   export let required: boolean | number = false
   export let resetFilterOnAdd: boolean = true
   export let searchText: string = ``
-  export let selected: InferredOption[] =
+  export let selected: Option[] =
     options
       ?.filter((op) => (op as ObjectOption)?.preselected)
       .slice(0, maxSelect ?? undefined) ?? []
-  export let sortSelected:
-    | boolean
-    | ((op1: InferredOption, op2: InferredOption) => number) = false
+  export let sortSelected: boolean | ((op1: Option, op2: Option) => number) = false
   export let selectedOptionsDraggable: boolean = !sortSelected
   export let ulOptionsClass: string = ``
   export let ulSelectedClass: string = ``
-  export let value: InferredOption | InferredOption[] | null = null
+  export let value: Option | Option[] | null = null
 
   // get the label key from an option object or the option itself if it's a string or number
-  const get_label = (op: InferredOption) => (op instanceof Object ? op.label : op)
+  const get_label = (op: Option) => (op instanceof Object ? op.label : op)
 
   // if maxSelect=1, value is the single item in selected (or null if selected is empty)
   // this solves both https://github.com/janosh/svelte-multiselect/issues/86 and
@@ -188,7 +184,7 @@
       } else {
         selected = [...selected, option]
         if (sortSelected === true) {
-          selected = selected.sort((op1: InferredOption, op2: InferredOption) => {
+          selected = selected.sort((op1: Option, op2: Option) => {
             const [label1, label2] = [get_label(op1), get_label(op2)]
             // coerce to string if labels are numbers
             return `${label1}`.localeCompare(`${label2}`)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -6,8 +6,10 @@
   import { CrossIcon, DisabledIcon, ExpandIcon } from './icons'
   import Wiggle from './Wiggle.svelte'
 
+  type InferredOption = $$Generic<Option>;
+
   export let activeIndex: number | null = null
-  export let activeOption: Option | null = null
+  export let activeOption: InferredOption | null = null
   export let addOptionMsg: string = `Create this option...`
   export let allowUserOptions: boolean | 'append' = false
   export let autocomplete: string = `off`
@@ -17,11 +19,11 @@
   export let disabled: boolean = false
   export let disabledInputTitle: string = `This input is disabled`
   // case-insensitive equality comparison after string coercion (looking only at the `label` key of object options)
-  export let duplicateFunc: (op1: Option, op2: Option) => boolean = (op1, op2) =>
+  export let duplicateFunc: (op1: InferredOption, op2: InferredOption) => boolean = (op1, op2) =>
     `${get_label(op1)}`.toLowerCase() === `${get_label(op2)}`.toLowerCase()
   export let duplicateOptionMsg: string = `This option is already selected`
   export let duplicates: boolean = false // whether to allow duplicate options
-  export let filterFunc = (op: Option, searchText: string): boolean => {
+  export let filterFunc = (op: InferredOption, searchText: string): boolean => {
     if (!searchText) return true
     return `${get_label(op)}`.toLowerCase().includes(searchText.toLowerCase())
   }
@@ -36,7 +38,7 @@
   export let liOptionClass: string = ``
   export let liSelectedClass: string = ``
   export let loading: boolean = false
-  export let matchingOptions: Option[] = []
+  export let matchingOptions: InferredOption[] = []
   export let maxSelect: number | null = null // null means there is no upper limit for selected.length
   export let maxSelectMsg: ((current: number, max: number) => string) | null = (
     current: number,
@@ -46,7 +48,7 @@
   export let name: string | null = null
   export let noMatchingOptionsMsg: string = `No matching options`
   export let open: boolean = false
-  export let options: Option[]
+  export let options: InferredOption[]
   export let outerDiv: HTMLDivElement | null = null
   export let outerDivClass: string = ``
   export let parseLabelsAsHtml: boolean = false // should not be combined with allowUserOptions!
@@ -58,18 +60,18 @@
   export let required: boolean | number = false
   export let resetFilterOnAdd: boolean = true
   export let searchText: string = ``
-  export let selected: Option[] =
+  export let selected: InferredOption[] =
     options
       ?.filter((op) => (op as ObjectOption)?.preselected)
       .slice(0, maxSelect ?? undefined) ?? []
-  export let sortSelected: boolean | ((op1: Option, op2: Option) => number) = false
+  export let sortSelected: boolean | ((op1: InferredOption, op2: InferredOption) => number) = false
   export let selectedOptionsDraggable: boolean = !sortSelected
   export let ulOptionsClass: string = ``
   export let ulSelectedClass: string = ``
-  export let value: Option | Option[] | null = null
+  export let value: InferredOption | InferredOption[] | null = null
 
   // get the label key from an option object or the option itself if it's a string or number
-  const get_label = (op: Option) => (op instanceof Object ? op.label : op)
+  const get_label = (op: InferredOption) => (op instanceof Object ? op.label : op)
 
   // if maxSelect=1, value is the single item in selected (or null if selected is empty)
   // this solves both https://github.com/janosh/svelte-multiselect/issues/86 and
@@ -182,7 +184,7 @@
       } else {
         selected = [...selected, option]
         if (sortSelected === true) {
-          selected = selected.sort((op1: Option, op2: Option) => {
+          selected = selected.sort((op1: InferredOption, op2: InferredOption) => {
             const [label1, label2] = [get_label(op1), get_label(op2)]
             // coerce to string if labels are numbers
             return `${label1}`.localeCompare(`${label2}`)


### PR DESCRIPTION
Closes #78.

## Summary of major changes

1. adds type inference for the `options` prop 
2. updates documentation for the same

## Checklist

[ ] has tests for any new functionality or bug fixes
[ ] has examples/docs for any new functionality
