### PR TITLE
Add prop allowEmpty: boolean = false

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {
     "@iconify/svelte": "^3.0.1",
     "@playwright/test": "^1.29.2",
-    "@sveltejs/adapter-static": "^1.0.4",
-    "@sveltejs/kit": "^1.1.1",
+    "@sveltejs/adapter-static": "^1.0.5",
+    "@sveltejs/kit": "^1.2.0",
     "@sveltejs/package": "1.0.2",
     "@sveltejs/vite-plugin-svelte": "^2.0.2",
     "@typescript-eslint/eslint-plugin": "^5.48.2",

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,12 @@ Full list of props/bindable variables for this component. The `Option` type you 
    Message shown to users after entering text when no options match their query and `allowUserOptions` is truthy.
 
 1. ```ts
+   allowEmpty: boolean = false
+   ```
+
+   Whether to `console.error` if dropdown list of options is empty. `allowEmpty={false}` will suppress errors. `allowEmpty={true}` will report a console error if component is not `disabled`, not in `loading` state and doesn't `allowUserOptions`.
+
+1. ```ts
    allowUserOptions: boolean | 'append' = false
    ```
 

--- a/src/app.css
+++ b/src/app.css
@@ -148,6 +148,7 @@ aside.toc.desktop {
 }
 
 /* TODO remove this tmp style */
-nav:has(+ div.code-example) > a {
+nav:has(+ div.code-example) > a,
+section > aside > a.btn {
   margin: 0;
 }

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -11,6 +11,7 @@
   export let activeOption: Option | null = null
   export let addOptionMsg: string = `Create this option...`
   export let allowUserOptions: boolean | 'append' = false
+  export let allowEmpty: boolean = false // added for https://github.com/janosh/svelte-multiselect/issues/192
   export let autocomplete: string = `off`
   export let autoScroll: boolean = true
   export let breakpoint: number = 800 // any screen with more horizontal pixels is considered desktop, below is mobile
@@ -83,18 +84,13 @@
   type $$Events = MultiSelectEvents // for type-safe event listening on this component
 
   if (!(options?.length > 0)) {
-    if (allowUserOptions || loading || disabled) {
+    if (allowUserOptions || loading || disabled || allowEmpty) {
       options = [] // initializing as array avoids errors when component mounts
     } else {
-      // only error for empty options if user is not allowed to create custom
-      // options and loading is false
+      // error on empty options if user is not allowed to create custom options and loading is false
+      // and component is not disabled and allowEmpty is false
       console.error(`MultiSelect received no options`)
     }
-  }
-  if (parseLabelsAsHtml && allowUserOptions) {
-    console.warn(
-      `Don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`
-    )
   }
   if (maxSelect !== null && maxSelect < 1) {
     console.error(
@@ -109,6 +105,11 @@
   if (maxSelect && typeof required === `number` && required > maxSelect) {
     console.error(
       `MultiSelect maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`
+    )
+  }
+  if (parseLabelsAsHtml && allowUserOptions) {
+    console.warn(
+      `Don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`
     )
   }
   if (sortSelected && selectedOptionsDraggable) {

--- a/src/routes/(demos)/ui/+page.svx
+++ b/src/routes/(demos)/ui/+page.svx
@@ -25,19 +25,19 @@ This page is used for Playwright testing to ensure
   - removes all currently selected options from the input
   - only appears if 2 or more elements are selected
   - has custom title (if supplied via prop `removeAllTitle`)
-- component can be focused
+- the component can be focused
   - which opens dropdown
-  - and closes dropdown when user tabs out of input or clicks/taps outside component
-  - importantly, we don't close dropdown when input looses focus
+  - and closes the dropdown when the user tabs out of input or clicks/taps outside component
+  - importantly, don't close the dropdown when input loses focus
 - filters options to only list matches when entering text
 - accessibility
-  - input is `aria-invalid` when component has `invalid=true`
+  - input is `aria-invalid` when the component has `invalid=true`
   - has `aria-expanded='false'` when closed
   - has `aria-expanded='true'` when open
   - options have `aria-selected='false'` and selected items have `aria-selected='true`
   - invisible `input.form-control` is `aria-hidden`
 
-<!-- TODO figure out why the Playwright test 'loops through dropdown list with arrow keys making...'
+<!-- TODO figure out why Playwright test 'loops through the dropdown list with arrow keys making...'
 depends on `html { scroll-behavior: smooth; }` -->
 <style>
   :global(html) {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -58,6 +58,7 @@ export default {
   },
 
   compilerOptions: {
+    // https://github.com/janosh/svelte-multiselect/issues/196
     immutable: true,
   },
 }

--- a/tests/unit/multiselect.test.ts
+++ b/tests/unit/multiselect.test.ts
@@ -904,3 +904,28 @@ test.each([[true], [false]])(
     }
   }
 )
+
+describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
+  describe.each([[true], [false]])(`disabled=%s`, (disabled) => {
+    test.each([[true], [false]])(
+      `console.error when allowEmpty=false and multiselect has no options`,
+      async (allowEmpty) => {
+        console.error = vi.fn()
+
+        new MultiSelect({
+          target: document.body,
+          props: { options: [], allowEmpty, disabled, allowUserOptions },
+        })
+
+        if (!allowEmpty && !disabled && !allowUserOptions) {
+          expect(console.error).toHaveBeenCalledTimes(1)
+          expect(console.error).toHaveBeenCalledWith(
+            `MultiSelect received no options`
+          )
+        } else {
+          expect(console.error).toHaveBeenCalledTimes(0)
+        }
+      }
+    )
+  })
+})


### PR DESCRIPTION
Can be used to suppress errors about empty multiselect when dynamically fetching options only once user starts entering `searchText`.

For #192.
