### PR TITLE
fix: add missing role attr for <li>

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -583,6 +583,7 @@
             on:focus={() => (add_option_msg_is_active = true)}
             on:mouseout={() => (add_option_msg_is_active = false)}
             on:blur={() => (add_option_msg_is_active = false)}
+            role="option"
             aria-selected="false"
           >
             {!duplicates && selected.some((option) => duplicateFunc(option, searchText))


### PR DESCRIPTION
## Summary of major changes

add the missing role attr for the `<li>` element to fix the a11y warning

![image](https://user-images.githubusercontent.com/25318236/224535960-c1ca81d8-aaca-4cb9-b5f3-62e0099cba94.png)


## Checklist

[x] has tests for any new functionality or bug fixes
[ ] has examples/docs for any new functionality
