### PR TITLE
Fix Svelte 3.57 a11y

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: package.json
 
       - name: Install dependencies
-        run: npm install --force
+        run: npm install
 
       - name: Build site
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install --force
+          npm install
           npx playwright install chromium
 
       - name: Run tests
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build package and publish to NPM
         run: |
-          npm install --force
+          npm install
           npm run package
           npm login --auth-type=legacy
           npm publish

--- a/contributing.md
+++ b/contributing.md
@@ -18,11 +18,11 @@ npm run dev
 Before you start committing, create and check out a descriptively named branch:
 
 ```sh
-git checkout -b <my-cool-new-feature>
+git checkout -b my-cool-new-feature
 # or
-git checkout -b <docs-on-something>
+git checkout -b docs-on-something
 # or
-git checkout -b <test-some-feature>
+git checkout -b test-some-feature
 ```
 
 To ensure your changes didn't break anything, run the full test suite (which also runs in CI):

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
     "update-coverage": "vitest tests/unit --run --coverage && npx istanbul-badges-readme"
   },
   "dependencies": {
-    "svelte": "^3.56.0"
+    "svelte": "^3.57.0"
   },
   "devDependencies": {
     "@iconify/svelte": "^3.1.0",
     "@playwright/test": "^1.31.2",
     "@sveltejs/adapter-static": "^2.0.1",
-    "@sveltejs/kit": "^1.11.0",
+    "@sveltejs/kit": "^1.12.0",
     "@sveltejs/package": "2.0.2",
     "@sveltejs/vite-plugin-svelte": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
-    "@vitest/coverage-c8": "^0.29.2",
+    "@vitest/coverage-c8": "^0.29.3",
     "eslint": "^8.36.0",
     "eslint-plugin-svelte3": "^4.0.0",
     "hastscript": "^7.2.0",
@@ -47,13 +47,13 @@
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.1.0",
     "svelte-check": "^3.1.4",
-    "svelte-preprocess": "^5.0.2",
-    "svelte-toc": "^0.5.3",
+    "svelte-preprocess": "^5.0.3",
+    "svelte-toc": "^0.5.4",
     "svelte-zoo": "^0.4.3",
-    "svelte2tsx": "^0.6.9",
-    "typescript": "5.0.1-rc",
-    "vite": "^4.1.4",
-    "vitest": "^0.29.2"
+    "svelte2tsx": "^0.6.10",
+    "typescript": "5.0.2",
+    "vite": "^4.2.0",
+    "vitest": "^0.29.3"
   },
   "keywords": [
     "svelte",

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -467,17 +467,10 @@
   <slot name="expand-icon" {open}>
     <ExpandIcon width="15px" style="min-width: 1em; padding: 0 1pt; cursor: pointer;" />
   </slot>
-  <ul
-    class="selected {ulSelectedClass}"
-    role="listbox"
-    aria-multiselectable={maxSelect === null || maxSelect > 1}
-    aria-label="selected options"
-  >
+  <ul class="selected {ulSelectedClass}" aria-label="selected options">
     {#each selected as option, idx (get_label(option))}
       <li
         class={liSelectedClass}
-        role="option"
-        aria-selected="true"
         animate:flip={{ duration: 100 }}
         draggable={selectedOptionsDraggable && !disabled && selected.length > 1}
         on:dragstart={dragstart(idx)}
@@ -574,15 +567,7 @@
 
   <!-- only render options dropdown if options or searchText is not empty needed to avoid briefly flashing empty dropdown -->
   {#if (searchText && noMatchingOptionsMsg) || options?.length > 0}
-    <ul
-      class:hidden={!open}
-      class="options {ulOptionsClass}"
-      role="listbox"
-      aria-multiselectable={maxSelect === null || maxSelect > 1}
-      aria-expanded={open}
-      aria-disabled={disabled ? `true` : null}
-      bind:this={ul_options}
-    >
+    <ul class:hidden={!open} class="options {ulOptionsClass}" bind:this={ul_options}>
       {#each matchingOptions as option, idx}
         {@const {
           label,
@@ -612,8 +597,6 @@
           }}
           on:mouseout={() => (activeIndex = null)}
           on:blur={() => (activeIndex = null)}
-          role="option"
-          aria-selected="false"
         >
           <slot name="option" {option} {idx}>
             {#if parseLabelsAsHtml}
@@ -634,8 +617,6 @@
             on:focus={() => (add_option_msg_is_active = true)}
             on:mouseout={() => (add_option_msg_is_active = false)}
             on:blur={() => (add_option_msg_is_active = false)}
-            role="option"
-            aria-selected="false"
           >
             {!duplicates && selected.some((option) => duplicateFunc(option, searchText))
               ? duplicateOptionMsg

--- a/src/routes/(demos)/ui/+page.svx
+++ b/src/routes/(demos)/ui/+page.svx
@@ -32,8 +32,6 @@ This page is used for Playwright testing to ensure
 - filters options to only list matches when entering text
 - accessibility
   - input is `aria-invalid` when the component has `invalid=true`
-  - has `aria-expanded='false'` when closed
-  - has `aria-expanded='true'` when open
   - options have `aria-selected='false'` and selected items have `aria-selected='true`
   - invisible `input.form-control` is `aria-hidden`
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -46,7 +46,6 @@ export default {
 
     alias: {
       $root: `.`,
-      $src: `./src`,
       $site: `./src/site`,
     },
   },

--- a/tests/MultiSelect.test.ts
+++ b/tests/MultiSelect.test.ts
@@ -145,11 +145,6 @@ test.describe(`disabled multiselect`, async () => {
     await page.goto(`/disabled`, { waitUntil: `networkidle` })
   })
 
-  test(`has attribute aria-disabled`, async ({ page }) => {
-    const div = await page.$(`div.multiselect.disabled ul.options`)
-    expect(await div?.getAttribute(`aria-disabled`)).toBe(`true`)
-  })
-
   test(`has disabled title`, async ({ page }) => {
     const div = await page.$(`div.multiselect.disabled`)
     expect(await div?.getAttribute(`title`)).toBe(
@@ -191,42 +186,6 @@ test.describe(`accessibility`, async () => {
       }
     )
     expect(invalid).toBe(`true`)
-  })
-
-  test(`has aria-expanded='false' when closed`, async ({ page }) => {
-    const before = await page.getAttribute(
-      `div.multiselect ul.options`,
-      `aria-expanded`,
-      { strict: true }
-    )
-    expect(before).toBe(`false`)
-  })
-
-  test(`has aria-expanded='true' when open`, async ({ page }) => {
-    await page.click(`div.multiselect`) // open the dropdown
-    const after = await page.getAttribute(
-      `div.multiselect ul.options`,
-      `aria-expanded`,
-      { strict: true }
-    )
-    expect(after).toBe(`true`)
-  })
-
-  test(`options have aria-selected='false' and selected items have aria-selected='true'`, async ({
-    page,
-  }) => {
-    await page.click(`div.multiselect`) // open the dropdown
-    await page.click(`div.multiselect > ul.options > li`) // select 1st option
-    const aria_option = await page.getAttribute(
-      `div.multiselect > ul.options > li`,
-      `aria-selected`
-    )
-    expect(aria_option).toBe(`false`)
-    const aria_selected = await page.getAttribute(
-      `div.multiselect > ul.selected > li`,
-      `aria-selected`
-    )
-    expect(aria_selected).toBe(`true`)
   })
 
   test(`invisible input.form-control is aria-hidden`, async ({ page }) => {
@@ -516,12 +475,12 @@ test.describe(`maxSelect`, async () => {
   test(`no more options can be added after reaching maxSelect items`, async ({
     page,
   }) => {
-    // query for li[aria-selected=true] to avoid matching the ul.selected > li containing the <input/>
-    let selected_lis = await page.$$(`ul.selected > li[aria-selected=true]`)
+    // query for li:not(:has(input)) to avoid matching the ul.selected > li containing the <input/>
+    let selected_lis = await page.$$(`ul.selected > li:not(:has(input))`)
     expect(selected_lis).toHaveLength(max_select)
     await page.click(`#languages input[autocomplete]`) // re-open options dropdown
     await page.click(`ul.options > li >> nth=0`)
-    selected_lis = await page.$$(`ul.selected > li[aria-selected=true]`)
+    selected_lis = await page.$$(`ul.selected > li:not(:has(input))`)
     expect(selected_lis).toHaveLength(max_select)
   })
 })


### PR DESCRIPTION
Updating to Svelte v3.57 surfaced a lot of a11y issues. Apparently, most uses of `aria` attributes in this component were incorrect. Don't have the expertise or time to 2nd guess this so I'll just assume whoever added these checks to the Svelte compiler knows what they're doing. Hence dropping all the flagged `aria` attributes.

![Screenshot 2023-03-17 at 10 07 31](https://user-images.githubusercontent.com/30958850/225973959-db5cb935-38df-4398-86a6-0ecbb169b1b6.png)
