### PR TITLE
fix: hide dropdown when custom messages are empty

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ Closes #issue.
 
 ## Checklist
 
-[ ] has tests for any new functionality or bug fixes
-[ ] has examples/docs for any new functionality
+[ ] has tests (only needed if any new functionality was added or bugs fixed)
+[ ] has examples/docs (only needed if any new functionality was added)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -124,7 +124,14 @@
   }
   if (sortSelected && selectedOptionsDraggable) {
     console.warn(
-      `MultiSelect's sortSelected and selectedOptionsDraggable should not be combined as any user re-orderings of selected options will be undone by sortSelected on component re-renders.`
+      `MultiSelect's sortSelected and selectedOptionsDraggable should not be combined as any ` +
+        `user re-orderings of selected options will be undone by sortSelected on component re-renders.`
+    )
+  }
+  if (allowUserOptions && !createOptionMsg) {
+    console.error(
+      `MultiSelect's allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
+        `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`
     )
   }
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -129,7 +129,7 @@
   }
 
   const dispatch = createEventDispatcher<DispatchEvents<Option>>()
-  let add_option_msg_is_active: boolean = false // controls active state of <li>{createOptionMsg}</li>
+  let option_msg_is_active: boolean = false // controls active state of <li>{createOptionMsg}</li>
   let window_width: number
 
   // options matching the current search text
@@ -291,7 +291,7 @@
       } else if (allowUserOptions && !matchingOptions.length && searchText.length > 0) {
         // if allowUserOptions is truthy and user entered text but no options match, we make
         // <li>{addUserMsg}</li> active on keydown (or toggle it if already active)
-        add_option_msg_is_active = !add_option_msg_is_active
+        option_msg_is_active = !option_msg_is_active
         return
       } else if (activeIndex === null) {
         // if no option is active and no options are matching, do nothing
@@ -607,24 +607,26 @@
           </slot>
         </li>
       {:else}
-        {#if allowUserOptions && searchText}
+        {@const hasDuplicates =
+          !duplicates && selected.some((option) => duplicateFunc(option, searchText))}
+        {@const optionMessage = hasDuplicates ? duplicateOptionMsg : createOptionMsg}
+        {#if allowUserOptions && searchText && optionMessage}
           <li
             on:mousedown|stopPropagation
             on:mouseup|stopPropagation={(event) => add(searchText, event)}
             title={createOptionMsg}
-            class:active={add_option_msg_is_active}
-            on:mouseover={() => (add_option_msg_is_active = true)}
-            on:focus={() => (add_option_msg_is_active = true)}
-            on:mouseout={() => (add_option_msg_is_active = false)}
-            on:blur={() => (add_option_msg_is_active = false)}
+            class:active={option_msg_is_active}
+            on:mouseover={() => (option_msg_is_active = true)}
+            on:focus={() => (option_msg_is_active = true)}
+            on:mouseout={() => (option_msg_is_active = false)}
+            on:blur={() => (option_msg_is_active = false)}
           >
-            {!duplicates && selected.some((option) => duplicateFunc(option, searchText))
-              ? duplicateOptionMsg
-              : createOptionMsg}
+            {optionMessage}
           </li>
-        {:else}
+        {:else if noMatchingOptionsMsg}
           <span>{noMatchingOptionsMsg}</span>
         {/if}
+        <!-- Show nothing if no messages are empty -->
       {/each}
     </ul>
   {/if}

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -774,8 +774,9 @@
     cursor: pointer;
     scroll-margin: var(--sms-options-scroll-margin, 100px);
   }
-  /* for noOptionsMsg */
-  :where(div.multiselect > ul.options span) {
+  :where(div.multiselect > ul.options .user-msg) {
+    /* block needed so vertical padding applies to span */
+    display: block;
     padding: 3pt 2ex;
   }
   :where(div.multiselect > ul.options > li.selected) {

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -607,10 +607,12 @@
           </slot>
         </li>
       {:else}
-        {@const hasDuplicates =
-          !duplicates && selected.some((option) => duplicateFunc(option, searchText))}
-        {@const optionMessage = hasDuplicates ? duplicateOptionMsg : createOptionMsg}
-        {#if allowUserOptions && searchText && optionMessage}
+        {@const search_is_duplicate = selected.some((option) =>
+          duplicateFunc(option, searchText)
+        )}
+        {@const msg =
+          !duplicates && search_is_duplicate ? duplicateOptionMsg : createOptionMsg}
+        {#if allowUserOptions && searchText && msg}
           <li
             on:mousedown|stopPropagation
             on:mouseup|stopPropagation={(event) => add(searchText, event)}
@@ -620,13 +622,15 @@
             on:focus={() => (option_msg_is_active = true)}
             on:mouseout={() => (option_msg_is_active = false)}
             on:blur={() => (option_msg_is_active = false)}
+            class="user-msg"
           >
-            {optionMessage}
+            {msg}
           </li>
         {:else if noMatchingOptionsMsg}
-          <span>{noMatchingOptionsMsg}</span>
+          <!-- use span to not have cursor: pointer -->
+          <span class="user-msg">{noMatchingOptionsMsg}</span>
         {/if}
-        <!-- Show nothing if no messages are empty -->
+        <!-- Show nothing if all messages are empty -->
       {/each}
     </ul>
   {/if}

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -906,6 +906,30 @@ test.each([[true], [false]])(
 )
 
 describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
+  test.each([[`create option`], [``], [null]])(
+    `console.error when allowUserOptions is truthy but createOptionMsg is falsy`,
+    async (createOptionMsg) => {
+      console.error = vi.fn()
+
+      new MultiSelect({
+        target: document.body,
+        props: { options: [1, 2, 3], createOptionMsg, allowUserOptions },
+      })
+
+      if (allowUserOptions && !createOptionMsg) {
+        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error).toHaveBeenCalledWith(
+          `MultiSelect's allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
+            `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`
+        )
+      } else {
+        expect(console.error).toHaveBeenCalledTimes(0)
+      }
+    }
+  )
+})
+
+describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
   describe.each([[true], [false]])(`disabled=%s`, (disabled) => {
     test.each([[true], [false]])(
       `console.error when allowEmpty=false and multiselect has no options`,

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -906,7 +906,7 @@ test.each([[true], [false]])(
 )
 
 describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
-  test.each([[`create option`], [``], [null]])(
+  test.each([[`create option`], [``]])(
     `console.error when allowUserOptions is truthy but createOptionMsg is falsy`,
     async (createOptionMsg) => {
       console.error = vi.fn()
@@ -1049,3 +1049,47 @@ test.each([[true], [false]])(
     )
   }
 )
+
+describe.each([[true], [false]])(`allowUserOptions=%s`, (allowUserOptions) => {
+  describe.each([[``], [`no matches`]])(
+    `noMatchingOptionsMsg=%s`,
+    (noMatchingOptionsMsg) => {
+      describe.each([[`make option`], [``]])(
+        `createOptionMsg='%s'`,
+        (createOptionMsg) => {
+          test(`no .user-msg node is rendered if in a state where noMatchingOptionsMsg or createOptionMsg would be shown but are falsy`, async () => {
+            new MultiSelect({
+              target: document.body,
+              props: {
+                options: [`foo`],
+                selected: [`foo`],
+                noMatchingOptionsMsg,
+                createOptionMsg,
+                allowUserOptions,
+              },
+            })
+
+            const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
+            // create a state where no options match the search text
+            input.value = `bar`
+            input.dispatchEvent(new InputEvent(`input`))
+
+            await tick()
+
+            if (allowUserOptions && createOptionMsg) {
+              expect(doc_query(`.user-msg`).textContent?.trim()).toBe(
+                createOptionMsg
+              )
+            } else if (noMatchingOptionsMsg) {
+              expect(doc_query(`.user-msg`).textContent?.trim()).toBe(
+                noMatchingOptionsMsg
+              )
+            } else {
+              expect(document.querySelector(`.user-msg`)).toBeNull()
+            }
+          })
+        }
+      )
+    }
+  )
+})


### PR DESCRIPTION
Closes #219 

## Summary of major changes

- Aggregated the messages as `optionMessage` in a @const
- Don't show the `<li/>` element if the optionMessage is empty
- Renamed `add_option_msg_is_active` to `option_msg_is_active` for clarity

### Before
<img width="833" alt="image" src="https://user-images.githubusercontent.com/64989428/229214470-db15acac-136d-48d5-a6a7-98cce12fdd33.png">

### After 
<img width="833" alt="image" src="https://user-images.githubusercontent.com/64989428/229214690-2671281e-575d-407a-bd77-4efb80626d31.png">

## Checklist

[ ] ~~has tests for any new functionality or bug fixes~~ -> Not applicable I believe
[ ] ~~has examples/docs for any new functionality~~ -> Not applicable
