### PR TITLE
Automatically add "bug" label to bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Help improve this project by pointing out bugs
+labels: [bug]
 ---
 
 A concise description of what's going wrong.


### PR DESCRIPTION
Closes NONE.


1. Automatically adds the `bug` label to all issues created with the `Bug Report` issue template