### PR TITLE
Fix [svelte-check] Cannot find module 'svelte-multiselect' or its corresponding type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
       "default": "./dist/index.js"
     }
   },
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ]


### PR DESCRIPTION
Declare [`"types"` (root-level) in `package.json`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package). Fixes #233.

From: https://github.com/janosh/svelte-multiselect/issues/233#issuecomment-1567287703
> The recommended fix is to update to TypeScript v5 and set "moduleResolution": "bundler". Let me know if that doesn't fix the issue or if something prevents you from upgrading.

This causes other problems for me. `svelte-check` can fail on some libraries when `"moduleResolution"` is changed. 

The fix in this PR does not require the user to make changes to `tsconfig.json/"compilerOptions"/"moduleResolution"`.
