### PR TITLE
v10.0.0

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,21 +1,15 @@
-root: true
 env:
   browser: true
-  es2020: true
   node: true
-parser: '@typescript-eslint/parser'
-parserOptions:
-  sourceType: module
-  ecmaVersion: latest
-plugins: [svelte3, '@typescript-eslint']
 extends:
+  - plugin:svelte/recommended
   - eslint:recommended
   - plugin:@typescript-eslint/recommended
 overrides:
   - files: ['*.svelte']
-    processor: svelte3/svelte3
-settings:
-  svelte3/typescript: true
+    parser: svelte-eslint-parser
+    parserOptions:
+      parser: '@typescript-eslint/parser'
 rules:
   indent: [error, 2, SwitchCase: 1]
   '@typescript-eslint/quotes': [error, backtick, avoidEscape: true]
@@ -23,6 +17,11 @@ rules:
   linebreak-style: [error, unix]
   no-console: [error, allow: [warn, error]]
   no-var: error
-  # allow triple slash for typescript file referencing https://git.io/JCeqO
-  spaced-comment: [error, always, { markers: [/] }]
   '@typescript-eslint/no-inferrable-types': off
+  '@typescript-eslint/no-unused-vars':
+    [error, { argsIgnorePattern: ^_, varsIgnorePattern: ^_ }]
+  svelte/no-at-html-tags: off
+  no-inner-declarations: off
+ignorePatterns: [build/, dist/]
+globals:
+  $$Generic: readonly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,3 @@ on:
 jobs:
   tests:
     uses: janosh/workflows/.github/workflows/npm-test-release.yml@main
-    with:
-      install-cmd: npm install --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,18 +37,20 @@ repos:
         exclude: changelog\.md
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.41.0
+    rev: v8.43.0
     hooks:
       - id: eslint
         types: [file]
-        args: [--fix, --plugin, 'svelte3, @typescript-eslint']
+        args: [--fix]
         files: \.(js|ts|svelte)$
         additional_dependencies:
           - eslint
+          - svelte
           - typescript
-          - eslint-plugin-svelte3
+          - eslint-plugin-svelte
           - '@typescript-eslint/eslint-plugin'
           - '@typescript-eslint/parser'
+          - svelte-eslint-parser
 
   - repo: local
     hooks:

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,19 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [v10.0.0](https://github.com/janosh/svelte-multiselect/compare/v9.0.0...v10.0.0)
+
+- Add Multiselect prop `maxOptions: number` [`#243`](https://github.com/janosh/svelte-multiselect/pull/243)
+- Add `&lt;slot name="user-msg"&gt;` [`#240`](https://github.com/janosh/svelte-multiselect/pull/240)
+- Rename prop `duplicateFunc()` to `key()` [`#238`](https://github.com/janosh/svelte-multiselect/pull/238)
+- declare types [`#236`](https://github.com/janosh/svelte-multiselect/pull/236)
+- add &lt;slot name="after-input"&gt; [`0fe8e8d`](https://github.com/janosh/svelte-multiselect/commit/0fe8e8d59e7dbfe8a650079c052a1ed7902c69fa)
+- add sentence on inputmode='none' use case for hiding on-screen keyboards to readme [`466f0a1`](https://github.com/janosh/svelte-multiselect/commit/466f0a12e866ba525194924902b67401397aa21f)
+
 ### [v9.0.0](https://github.com/janosh/svelte-multiselect/compare/v8.6.2...v9.0.0)
 
 > 1 June 2023
 
-- Prep v9 release [`#235`](https://github.com/janosh/svelte-multiselect/pull/235)
 - Revert "Fix Svelte 3.57 a11y (#215)" [`#232`](https://github.com/janosh/svelte-multiselect/pull/232)
 - Add default slot [`#231`](https://github.com/janosh/svelte-multiselect/pull/231)
 - CmdPalette add prop close_keys [`099e1ac`](https://github.com/janosh/svelte-multiselect/commit/099e1acbae8b66b0a10129ecb2930bb10920974f)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://janosh.github.io/svelte-multiselect",
   "repository": "https://github.com/janosh/svelte-multiselect",
   "license": "MIT",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "type": "module",
   "svelte": "./dist/index.js",
   "bugs": "https://github.com/janosh/svelte-multiselect/issues",

--- a/package.json
+++ b/package.json
@@ -23,24 +23,24 @@
     "update-coverage": "vitest tests/unit --run --coverage && npx istanbul-badges-readme"
   },
   "dependencies": {
-    "svelte": "^4.0.0"
+    "svelte": "^4.0.1"
   },
   "devDependencies": {
     "@iconify/svelte": "^3.1.4",
     "@playwright/test": "^1.35.1",
     "@sveltejs/adapter-static": "^2.0.2",
-    "@sveltejs/kit": "^1.20.5",
+    "@sveltejs/kit": "^1.21.0",
     "@sveltejs/package": "2.1.0",
     "@sveltejs/vite-plugin-svelte": "2.4.2",
-    "@typescript-eslint/eslint-plugin": "^5.60.0",
-    "@typescript-eslint/parser": "^5.60.0",
+    "@typescript-eslint/eslint-plugin": "^5.60.1",
+    "@typescript-eslint/parser": "^5.60.1",
     "@vitest/coverage-v8": "^0.32.2",
-    "eslint": "^8.43.0",
-    "eslint-plugin-svelte3": "^4.0.0",
+    "eslint": "^8.44.0",
+    "eslint-plugin-svelte": "^2.32.2",
     "hastscript": "^7.2.0",
     "highlight.js": "^11.8.0",
     "jsdom": "^22.1.0",
-    "mdsvex": "^0.10.6",
+    "mdsvex": "^0.11.0",
     "mdsvexamples": "^0.3.3",
     "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.10.1",
@@ -51,7 +51,7 @@
     "svelte-toc": "^0.5.5",
     "svelte-zoo": "^0.4.8",
     "svelte2tsx": "^0.6.16",
-    "typescript": "5.1.3",
+    "typescript": "5.1.6",
     "vite": "^4.3.9",
     "vitest": "^0.32.2"
   },

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,15 @@
   </MultiSelect>
   ```
 
+- **v10.0.0** (2023-06-23)&nbsp; `duplicateFunc()` renamed to `key` in [#238](https://github.com/janosh/svelte-multiselect/pull/238). Signature changed:
+
+  ```diff
+  - duplicateFunc: (op1: T, op2: T) => boolean = (op1, op2) => `${get_label(op1)}`.toLowerCase() === `${get_label(op2)}`.toLowerCase()
+  + key: (opt: T) => unknown = (opt) => `${get_label(opt)}`.toLowerCase()
+  ```
+
+  Rather than implementing custom equality in `duplicateFunc`, the `key` function is now expected to map options to a unique identifier. `key(op1) === key(op2)` should mean `op1` and `op2` are the same option. `key` can return any type but usually best to return primitives (`string`, `number`, ...) for Svelte keyed each blocks (see [#217](https://github.com/janosh/svelte-multiselect/pull/217)).
+
 ## 🔨 &thinsp; Installation
 
 ```sh

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -93,6 +93,7 @@
 
   let wiggle = false // controls wiggle animation when user tries to exceed maxSelect
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type $$Events = MultiSelectEvents // for type-safe event listening on this component
 
   if (!(options?.length > 0)) {

--- a/src/site/LanguageSlot.svelte
+++ b/src/site/LanguageSlot.svelte
@@ -2,7 +2,7 @@
   export let option: string
   export let idx: number | undefined = undefined
   export let height = `20px`
-  export let gap = '5pt'
+  export let gap = `5pt`
 
   $: lang = option.toLowerCase().replaceAll(`+`, `plus`).replace(`#`, `sharp`)
 


### PR DESCRIPTION
Prepare v10 release.

Drop deprecated https://github.com/sveltejs/eslint-plugin-svelte3 (last Svelte3-only dep)

Superseded by: https://github.com/sveltejs/eslint-plugin-svelte.