### PR TITLE
Add headless prop to remove default classes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,12 @@ Full list of props/bindable variables for this component. The `Option` type you 
    ```
 
    Whether to allow users to select duplicate options. Applies only to the selected item list, not the options dropdown. Keeping that free of duplicates is left to developer. The selected item list can have duplicates if `allowUserOptions` is truthy, `duplicates` is `true` and users create the same option multiple times. Use `duplicateOptionMsg` to customize the message shown to user if `duplicates` is `false` and users attempt this and `key` to customize when a pair of options is considered equal.
+ 
+1. ```ts
+   headless: boolean = false
+   ```
+
+   When `true`, the component will render without any styling. This is useful if you want to use your own styling or if you want to use the component as a headless component (i.e. without any UI).
 
 1. ```ts
    duplicateOptionMsg: string = `This option is already selected`
@@ -608,6 +614,8 @@ The second method allows you to pass in custom classes to the important DOM elem
 - `liOptionClass`: list items selectable from dropdown list
 - `liActiveOptionClass`: the currently active dropdown list item (i.e. hovered or navigated to with arrow keys)
 - `maxSelectMsgClass`: small span towards the right end of the input field displaying to the user how many of the allowed number of options they've already selected
+
+You can also use `headless = true` if you want to completely disable default classes.
 
 This simplified version of the DOM structure of the component shows where these classes are inserted:
 

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ Full list of props/bindable variables for this component. The `Option` type you 
    ```
 
    Whether to allow users to select duplicate options. Applies only to the selected item list, not the options dropdown. Keeping that free of duplicates is left to developer. The selected item list can have duplicates if `allowUserOptions` is truthy, `duplicates` is `true` and users create the same option multiple times. Use `duplicateOptionMsg` to customize the message shown to user if `duplicates` is `false` and users attempt this and `key` to customize when a pair of options is considered equal.
- 
+
 1. ```ts
    headless: boolean = false
    ```

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -21,6 +21,7 @@
   // prettier-ignore
   export let duplicateOptionMsg: string = `This option is already selected`
   export let duplicates: boolean = false // whether to allow duplicate options
+  export let headless: boolean = false
   // takes two options and returns true if they are equal
   // case-insensitive equality comparison after string coercion and looks only at the `label` key of object options by default
   export let key: (opt: T) => unknown = (opt) => `${get_label(opt)}`.toLowerCase()
@@ -464,7 +465,8 @@
   class:single={maxSelect === 1}
   class:open
   class:invalid
-  class="multiselect {outerDivClass}"
+  class:multiselect={!headless}
+  class={outerDivClass}
   on:mouseup|stopPropagation={open_dropdown}
   title={disabled ? disabledInputTitle : null}
   data-id={id}
@@ -498,7 +500,7 @@
   <slot name="expand-icon" {open}>
     <ExpandIcon width="15px" style="min-width: 1em; padding: 0 1pt; cursor: pointer;" />
   </slot>
-  <ul class="selected {ulSelectedClass}" aria-label="selected options">
+  <ul class:selected={!headless} class={ulSelectedClass} aria-label="selected options">
     {#each selected as option, idx (duplicates ? [key(option), idx] : key(option))}
       <li
         class={liSelectedClass}
@@ -591,7 +593,7 @@
   {:else if selected.length > 0}
     {#if maxSelect && (maxSelect > 1 || maxSelectMsg)}
       <Wiggle bind:wiggle angle={20}>
-        <span class="max-select-msg {maxSelectMsgClass}">
+        <span class:max-select-msg={!headless} class={maxSelectMsgClass}>
           {maxSelectMsg?.(selected.length, maxSelect)}
         </span>
       </Wiggle>
@@ -615,7 +617,8 @@
   {#if (searchText && noMatchingOptionsMsg) || options?.length > 0}
     <ul
       class:hidden={!open}
-      class="options {ulOptionsClass}"
+      class:options={!headless}
+      class={ulOptionsClass}
       role="listbox"
       aria-multiselectable={maxSelect === null || maxSelect > 1}
       aria-expanded={open}

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -1165,7 +1165,16 @@ test(`headless=true to remove default classes`, async () => {
       headless: true,
     },
   })
-  for (const missingClass of [`multiselect`, `options`, `selected`, `max-select-msg`, `remove-all`]) {
-    expect(document.querySelector(`.${missingClass}`), `when headless=true, the .multiselect node should not have the class .${missingClass}`).toBeNull()
+  for (const missingClass of [
+    `multiselect`,
+    `options`,
+    `selected`,
+    `max-select-msg`,
+    `remove-all`,
+  ]) {
+    expect(
+      document.querySelector(`.${missingClass}`),
+      `when headless=true, the .multiselect node should not have the class .${missingClass}`,
+    ).toBeNull()
   }
 })

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -1156,3 +1156,16 @@ test.each([[true], [-1], [3.5], [`foo`], [{}]])(
     )
   },
 )
+
+test(`headless=true to remove default classes`, async () => {
+  new MultiSelect({
+    target: document.body,
+    props: {
+      options: [`<a href="https://example.com">example.com</a>`],
+      headless: true,
+    },
+  })
+  for (const missingClass of [`multiselect`, `options`, `selected`, `max-select-msg`, `remove-all`]) {
+    expect(document.querySelector(`.${missingClass}`), `when headless=true, the .multiselect node should not have the class .${missingClass}`).toBeNull()
+  }
+})


### PR DESCRIPTION
Closes #247.

## Summary of major changes

1. adds headless prop to remove default classes

## Todos

1. Not sure about other classes. If we were to remove them also, we need to add a ton of props to be able to replace them. I think this is good enough for now and will increase flexibility without braking anything for existing users. 

## Checklist

[*] has tests (only needed if any new functionality was added or bugs fixed)
[*] has examples/docs (only needed if any new functionality was added)
