### PR TITLE
Make `selected` and `value` each reactive to each other

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
     "update-coverage": "vitest tests/unit --run --coverage && npx istanbul-badges-readme"
   },
   "dependencies": {
-    "svelte": "^4.0.1"
+    "svelte": "^4.0.5"
   },
   "devDependencies": {
     "@iconify/svelte": "^3.1.4",
     "@playwright/test": "^1.35.1",
     "@sveltejs/adapter-static": "^2.0.2",
-    "@sveltejs/kit": "^1.21.0",
+    "@sveltejs/kit": "^1.22.1",
     "@sveltejs/package": "2.1.0",
     "@sveltejs/vite-plugin-svelte": "2.4.2",
-    "@typescript-eslint/eslint-plugin": "^5.60.1",
-    "@typescript-eslint/parser": "^5.60.1",
-    "@vitest/coverage-v8": "^0.32.2",
+    "@typescript-eslint/eslint-plugin": "^5.61.0",
+    "@typescript-eslint/parser": "^5.61.0",
+    "@vitest/coverage-v8": "^0.33.0",
     "eslint": "^8.44.0",
     "eslint-plugin-svelte": "^2.32.2",
     "hastscript": "^7.2.0",
@@ -42,18 +42,18 @@
     "jsdom": "^22.1.0",
     "mdsvex": "^0.11.0",
     "mdsvexamples": "^0.3.3",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^2.10.1",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.1.0",
-    "svelte-check": "^3.4.4",
+    "svelte-check": "^3.4.5",
     "svelte-preprocess": "^5.0.4",
     "svelte-toc": "^0.5.5",
-    "svelte-zoo": "^0.4.8",
-    "svelte2tsx": "^0.6.16",
+    "svelte-zoo": "^0.4.9",
+    "svelte2tsx": "^0.6.19",
     "typescript": "5.1.6",
-    "vite": "^4.3.9",
-    "vitest": "^0.32.2"
+    "vite": "^4.4.2",
+    "vitest": "^0.33.0"
   },
   "keywords": [
     "svelte",

--- a/readme.md
+++ b/readme.md
@@ -385,7 +385,7 @@ Full list of props/bindable variables for this component. The `Option` type you 
    value: Option | Option[] | null = null
    ```
 
-   If `maxSelect={1}`, `value` will be the single item in `selected` (or `null` if `selected` is empty). If `maxSelect != 1`, `maxSelect` and `selected` are equal. Warning: `value` supports 1-way binding only, meaning `bind:value` will update `value` when internal component state changes but changing `value` externally will not update internal component state. This is because `value` is already reactive to `selected` and making `selected` reactive to `value` would be cyclic. Suggestions for better solutions that solve both [#86](https://github.com/janosh/svelte-multiselect/issues/86) and [#136](https://github.com/janosh/svelte-multiselect/issues/136) welcome!
+   If `maxSelect={1}`, `value` will be the single item in `selected` (or `null` if `selected` is empty). If `maxSelect != 1`, `maxSelect` and `selected` are equal. Warning: Setting `value` does not rendered state on initial mount, meaning `bind:value` will update local variable `value` whenever internal component state changes but passing a `value` when component first mounts won't be reflected in UI. This is because the source of truth for rendering is `bind:selected`. `selected` is reactive to `value` internally but only on reassignment from initial value. Suggestions for better solutions than [#249](https://github.com/janosh/svelte-multiselect/issues/249) welcome!
 
 ## 🎰 &thinsp; Slots
 

--- a/src/app.css
+++ b/src/app.css
@@ -11,7 +11,6 @@
   --sms-disabled-bg: rgba(7, 1, 34, 0.87);
   --sms-li-disabled-bg: black;
   --sms-placeholder-color: lightgray;
-  --sms-margin: 1em 0;
 
   --toc-mobile-bg: #1c0e3e;
   --toc-li-padding: 3pt 1ex;
@@ -21,6 +20,7 @@
 
   --zoo-github-corner-color: var(--night);
   --zoo-github-corner-bg: white;
+  --zoo-example-margin: 1em auto;
 }
 body {
   background: var(--night);

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -66,7 +66,7 @@
   export let selected: Option[] =
     options
       ?.filter((opt) => opt instanceof Object && opt?.preselected)
-      .slice(0, maxSelect ?? undefined) ?? []
+      .slice(0, maxSelect ?? undefined) ?? [] // don't allow more than maxSelect preselected options
   export let sortSelected: boolean | ((op1: Option, op2: Option) => number) = false
   export let selectedOptionsDraggable: boolean = !sortSelected
   export let ulOptionsClass: string = ``
@@ -86,10 +86,19 @@
     return `${opt}`
   }
 
+  const selected_to_value = (selected: Option[]) => {
+    value = maxSelect === 1 ? selected[0] ?? null : selected
+  }
+  const value_to_selected = (value: Option | Option[] | null) => {
+    if (maxSelect === 1) selected = value ? [value as Option] : []
+    else selected = (value as Option[]) ?? []
+  }
+
   // if maxSelect=1, value is the single item in selected (or null if selected is empty)
   // this solves both https://github.com/janosh/svelte-multiselect/issues/86 and
   // https://github.com/janosh/svelte-multiselect/issues/136
-  $: value = maxSelect === 1 ? selected[0] ?? null : selected
+  $: selected_to_value(selected)
+  $: value_to_selected(value)
 
   let wiggle = false // controls wiggle animation when user tries to exceed maxSelect
 

--- a/src/routes/(demos)/min-max-select/+page.svx
+++ b/src/routes/(demos)/min-max-select/+page.svx
@@ -80,3 +80,20 @@ Of course, you can combine `maxSelect={n}` and `required={m}` where `n>=m`.
   <button>submit</button>
 </form>
 ```
+
+```svelte example stackblitz
+<script>
+  // for https://github.com/janosh/svelte-multiselect/issues/249
+  import MultiSelect from '$lib'
+  import { onMount } from 'svelte'
+
+  const red_pill = `🔴  &ensp; Red Pill (<a href="https://wikipedia.org/wiki/Red_pill_and_blue_pill">wait what?</a>)`
+  const blue_pill = `🔵  &ensp; Blue Pill (<a href="https://i.guim.co.uk/img/media/b251ae63d78acf9389a8fce146580483ecdd2253/57_6_1416_849/master/1416.jpg?s=none" target="_blank">show me</a>)`
+  const options = [ { label: red_pill, value: `red pill` }, { label: blue_pill, value: `blue pill` }]
+
+  let value
+  onMount(() => value = options[0])
+</script>
+
+<MultiSelect {options} maxSelect={1} parseLabelsAsHtml bind:value />
+```

--- a/src/site/Examples.svx
+++ b/src/site/Examples.svx
@@ -178,7 +178,8 @@
 
 <style>
   label:not(:first-of-type) {
-    margin-top: 3em;
+    border-top: 0.5px solid #ccc;
+    padding-top: 2em;
     display: block;
   }
   label span {

--- a/tests/MultiSelect.test.ts
+++ b/tests/MultiSelect.test.ts
@@ -513,11 +513,15 @@ test.describe(`maxSelect`, async () => {
     page,
   }) => {
     // query for li[aria-selected=true] to avoid matching the ul.selected > li containing the <input/>
-    let selected_lis = await page.$$(`ul.selected > li[aria-selected=true]`)
+    let selected_lis = await page.$$(
+      `#languages ul.selected > li[aria-selected=true]`,
+    )
     expect(selected_lis).toHaveLength(max_select)
     await page.click(`#languages input[autocomplete]`) // re-open options dropdown
     await page.click(`ul.options > li >> nth=0`)
-    selected_lis = await page.$$(`ul.selected > li[aria-selected=true]`)
+    selected_lis = await page.$$(
+      `#languages ul.selected > li[aria-selected=true]`,
+    )
     expect(selected_lis).toHaveLength(max_select)
   })
 })

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -280,6 +280,29 @@ test(`value is null when maxSelect=1 and no option is pre-selected`, async () =>
   expect(select.value).toBe(null)
 })
 
+test.each([[null], [1]])(
+  `2-way binding of value updates selected`,
+  async (maxSelect) => {
+    const select = new MultiSelect({
+      target: document.body,
+      props: { options: [1, 2, 3], maxSelect },
+    })
+
+    expect(select.value).toEqual(maxSelect == 1 ? null : [])
+
+    await tick()
+    if (maxSelect == 1) {
+      select.value = 2
+      expect(select.value).toEqual(2)
+      expect(select.selected).toEqual([2])
+    } else {
+      select.value = [1, 2]
+      expect(select.value).toEqual([1, 2])
+      expect(select.selected).toEqual([1, 2])
+    }
+  },
+)
+
 test(`selected is array of first two options when maxSelect=2`, async () => {
   // even though all options have preselected=true
   const options = [1, 2, 3].map((itm) => ({

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -254,19 +254,24 @@ test(`bubbles <input> node DOM events`, async () => {
   }
 })
 
-test(`value is a single option (i.e. selected[0]) when maxSelect=1`, async () => {
-  const options = [1, 2, 3]
+describe.each([[null], [1]])(`value is `, (maxSelect) => {
+  test.each([[[1, 2, 3]], [[`a`, `b`, `c`]]])(
+    `${
+      maxSelect == 1 ? `single` : `multiple`
+    } options when maxSelect=${maxSelect}`,
+    async (options) => {
+      const select = new MultiSelect({
+        target: document.body,
+        props: { options, maxSelect, selected: options },
+      })
 
-  const select = new MultiSelect({
-    target: document.body,
-    props: { options, maxSelect: 1, selected: options },
-  })
-
-  // this also tests that only 1st option is pre-selected although all options are marked such, i.e. no more than maxSelect options can be pre-selected
-  expect(select.value).toBe(options[0])
+      // this also tests that only 1st option is pre-selected although all options are marked such, i.e. no more than maxSelect options can be pre-selected
+      expect(select.value).toBe(maxSelect == 1 ? options[0] : options)
+    },
+  )
 })
 
-test(`selected is null when maxSelect=1 and no option is pre-selected`, async () => {
+test(`value is null when maxSelect=1 and no option is pre-selected`, async () => {
   const select = new MultiSelect({
     target: document.body,
     props: { options: [1, 2, 3], maxSelect: 1 },
@@ -291,36 +296,33 @@ test(`selected is array of first two options when maxSelect=2`, async () => {
 })
 
 describe.each([
-  [false, [], true], // unrequired + empty selected = valid form
-  [true, [], false], // required + empty selected = invalid form
-  [1, [1], true], // required=1 + 1 selected = valid form
-  [2, [1], false], // required=2 + 1 selected = invalid form
-  [2, [1, 2], true], // required=2 + 2 selected = valid form
-])(
-  `MultiSelect with required=%s, selected=%s`,
-  (required, selected, form_valid) => {
-    test.each([1, 2, null])(
-      `${
-        form_valid ? `passes` : `doesn't pass`
-      } form validity check and maxSelect=%s`,
-      (maxSelect) => {
-        // i think, not passing validity check means form won't submit
-        // maybe TODO: simulating form submission event and checking
-        // event.defaultPrevented == true seems closer to ground truth but harder to test
+  [false, []],
+  [true, []],
+  [1, [1]],
+  [2, [1]],
+  [2, [1, 2]],
+])(`MultiSelect with required=%s, selected=%s`, (required, selected) => {
+  test.each([1, 2, null])(`and maxSelect=%s form validation`, (maxSelect) => {
+    // not passing validity check hopefully means form won't submit
+    // maybe TODO: simulate form submission event and check
+    // event.defaultPrevented == true seems closer to ground truth but harder to test
 
-        const form = document.createElement(`form`)
-        document.body.appendChild(form)
+    const form = document.createElement(`form`)
+    document.body.appendChild(form)
+    new MultiSelect({
+      target: form,
+      props: { options: [1, 2, 3], required, selected, maxSelect },
+    })
 
-        new MultiSelect({
-          target: form,
-          props: { options: [1, 2, 3], required, selected, maxSelect },
-        })
+    const form_valid =
+      !required ||
+      (selected.length >= Number(required) &&
+        selected.length <= (maxSelect ?? Infinity))
+    const msg = `form_valid=${form_valid}`
 
-        expect(form.checkValidity()).toBe(form_valid)
-      },
-    )
-  },
-)
+    expect(form.checkValidity(), msg).toBe(form_valid)
+  })
+})
 
 test.each([
   [0, 1, 0],


### PR DESCRIPTION
Closes #249.

Uses neat pattern found in [this REPL](https://svelte.dev/repl/fce6e30f34ee49c1b9674731dc40b395).