### PR TITLE
Breaking: rename `focusInputOnSelect` to `closeDropdownOnSelect`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -397,12 +397,10 @@ Full list of props/bindable variables for this component. The `Option` type you 
 1. `slot="disabled-icon"`: Custom icon to display inside the input when in `disabled` state. Receives no props. Use an empty `<span slot="disabled-icon" />` or `div` to remove the default disabled icon.
 1. `slot="expand-icon"`: Allows setting a custom icon to indicate to users that the Multiselect text input field is expandable into a dropdown list. Receives prop `open: boolean` which is true if the Multiselect dropdown is visible and false if it's hidden.
 1. `slot="remove-icon"`: Custom icon to display as remove button. Will be used both by buttons to remove individual selected options and the 'remove all' button that clears all options at once. Receives no props.
-1. `slot="user-msg"`: Displayed like a dropdown item when the list is empty and user is allowed to create custom options based on text input (or if the user's text input clashes with an existing option). `let:props`:
-   - `duplicateOptionMsg: string`: See [props](#🔣-props).
-   - `createOptionMsg: string`: See [props](#🔣-props).
-   - `textInputIsDuplicate: boolean`: Whether user has typed text that matches an already existing option.
-   - `searchText: string`: The text user typed into search input.
-   - `msg: string`: `duplicateOptionMsg` if user input is a duplicate else `createOptionMsg`.
+1. `slot="user-msg"`: Displayed like a dropdown item when the list is empty and user is allowed to create custom options based on text input (or if the user's text input clashes with an existing option). Receives props:
+   - `searchText`: The text user typed into search input.
+   - `msgType: false | 'create' | 'dupe' | 'no-match'`: `'dupe'` means user input is a duplicate of an existing option. `'create'` means user is allowed to convert their input into a new option not previously in the dropdown. `'no-match'` means user input doesn't match any dropdown items and users are not allowed to create new options. `false` means none of the above.
+   - `msg`: Will be `duplicateOptionMsg` or `createOptionMsg` (see [props](#🔣-props)) based on whether user input is a duplicate or can be created as new option. Note this slot replaces the default UI for displaying these messages so the slot needs to render them instead (unless purposely not showing a message).
 1. `slot='after-input'`: Placed after the search input. For arbitrary content like icons or temporary messages. Receives props `selected: Option[]`, `disabled: boolean`, `invalid: boolean`, `id: string | null`, `placeholder: string`, `open: boolean`, `required: boolean`. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
 
 Example using several slots:

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ Full list of props/bindable variables for this component. The `Option` type you 
    focusInputOnSelect: boolean | 'desktop' = `desktop`
    ```
 
-   One of `true`, `false` or `'desktop'`. Whether to move focus (and cursor) back to the input element after selecting a dropdown item. 'desktop' means `true` if current window width is larger than the current value of `breakpoint` prop (default is 800, meaning screen width in pixels).
+   One of `true`, `false` or `'desktop'`. Whether to move focus back to the input element after selecting a dropdown item. If `false`, component will loose focus and `dropdown` is closed. `'desktop'` means `true` if current window width is larger than the current value of `breakpoint` prop (default is 800, meaning screen width in pixels).
 
 1. ```ts
    form_input: HTMLInputElement | null = null

--- a/readme.md
+++ b/readme.md
@@ -194,10 +194,10 @@ Full list of props/bindable variables for this component. The `Option` type you 
    Customize how dropdown options are filtered when user enters search string into `<MultiSelect />`. Defaults to:
 
 1. ```ts
-   focusInputOnSelect: boolean | 'desktop' = `desktop`
+   closeDropdownOnSelect: boolean | 'desktop' = `desktop`
    ```
 
-   One of `true`, `false` or `'desktop'`. Whether to move focus back to the input element after selecting a dropdown item. If `false`, component will loose focus and `dropdown` is closed. `'desktop'` means `true` if current window width is larger than the current value of `breakpoint` prop (default is 800, meaning screen width in pixels).
+   One of `true`, `false` or `'desktop'`. Whether to close the dropdown list after selecting a dropdown item. If `true`, component will loose focus and `dropdown` is closed. `'desktop'` means `false` if current window width is larger than the current value of `breakpoint` prop (default is 800, meaning screen width in pixels). This is to align with the default behavior of many mobile browsers like Safari which close dropdowns after selecting an option while desktop browsers facilitate multi-selection by leaving dropdowns open.
 
 1. ```ts
    form_input: HTMLInputElement | null = null

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ Full list of props/bindable variables for this component. The `Option` type you 
    focusInputOnSelect: boolean | 'desktop' = `desktop`
    ```
 
-   One of `true`, `false` or `'desktop'`. Whether to set the cursor back to the input element after selecting an element. 'desktop' means only do so if current window width is larger than the current value of `breakpoint` prop (default 800).
+   One of `true`, `false` or `'desktop'`. Whether to move focus (and cursor) back to the input element after selecting a dropdown item. 'desktop' means `true` if current window width is larger than the current value of `breakpoint` prop (default is 800, meaning screen width in pixels).
 
 1. ```ts
    form_input: HTMLInputElement | null = null
@@ -403,7 +403,7 @@ Full list of props/bindable variables for this component. The `Option` type you 
    - `textInputIsDuplicate: boolean`: Whether user has typed text that matches an already existing option.
    - `searchText: string`: The text user typed into search input.
    - `msg: string`: `duplicateOptionMsg` if user input is a duplicate else `createOptionMsg`.
-1. `slot='after-input'`: ForPlaced after the search input. For arbitrary content like icons or temporary messages. Receives props `selected`, `disabled`, `invalid`, `id`, `placeholder`, `open`, `required`.
+1. `slot='after-input'`: Placed after the search input. For arbitrary content like icons or temporary messages. Receives props `selected: Option[]`, `disabled: boolean`, `invalid: boolean`, `id: string | null`, `placeholder: string`, `open: boolean`, `required: boolean`. Can serve as a more dynamic, more customizable alternative to the `placeholder` prop.
 
 Example using several slots:
 

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -667,9 +667,9 @@
       {#if searchText}
         {@const text_input_is_duplicate = selected.map(get_label).includes(searchText)}
         {@const is_dupe = !duplicates && text_input_is_duplicate && `dupe`}
-        {@const can_create = allowUserOptions && createOptionMsg && `create`}
+        {@const can_create = Boolean(allowUserOptions && createOptionMsg) && `create`}
         {@const no_match =
-          matchingOptions?.length == 0 && noMatchingOptionsMsg && `no-match`}
+          Boolean(matchingOptions?.length == 0 && noMatchingOptionsMsg) && `no-match`}
         {@const msgType = is_dupe || can_create || no_match}
         {#if msgType}
           {@const msg = {

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -221,11 +221,14 @@
           selected = selected.sort(sortSelected)
         }
       }
-      if (selected.length === maxSelect) close_dropdown(event)
-      else if (
+
+      const focus_input =
         focusInputOnSelect === true ||
         (focusInputOnSelect === `desktop` && window_width > breakpoint)
-      ) {
+
+      if (selected.length === maxSelect || !focus_input) {
+        close_dropdown(event)
+      } else if (focus_input) {
         input?.focus()
       }
       dispatch(`add`, { option })

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -29,7 +29,7 @@
     if (!searchText) return true
     return `${get_label(opt)}`.toLowerCase().includes(searchText.toLowerCase())
   }
-  export let focusInputOnSelect: boolean | 'desktop' = `desktop`
+  export let closeDropdownOnSelect: boolean | 'desktop' = `desktop`
   export let form_input: HTMLInputElement | null = null
   export let highlightMatches: boolean = true
   export let id: string | null = null
@@ -222,13 +222,15 @@
         }
       }
 
-      const focus_input =
-        focusInputOnSelect === true ||
-        (focusInputOnSelect === `desktop` && window_width > breakpoint)
+      const reached_max_select = selected.length === maxSelect
 
-      if (selected.length === maxSelect || !focus_input) {
+      const dropdown_should_close =
+        closeDropdownOnSelect === true ||
+        (closeDropdownOnSelect === `desktop` && window_width < breakpoint)
+
+      if (reached_max_select || dropdown_should_close) {
         close_dropdown(event)
-      } else if (focus_input) {
+      } else if (!dropdown_should_close) {
         input?.focus()
       }
       dispatch(`add`, { option })

--- a/src/routes/(demos)/slots/+page.svx
+++ b/src/routes/(demos)/slots/+page.svx
@@ -73,17 +73,20 @@
   import { languages } from '$site/options'
   import { LanguageSlot } from '$site'
   import { Icon } from 'svelte-zoo'
+
+  let selected = [`Python`, `TypeScript`, `Julia`]
+  let searchText = `Julia`
 </script>
 
 <MultiSelect
   options={languages}
+  bind:searchText
+  bind:selected
   maxSelect={5}
   placeholder="What languages do you know?"
-  selected={[`Python`, `TypeScript`, `Julia`]}
-  searchText="Julia"
   open
   allowUserOptions
 >
-  <span slot="user-msg" let:msg let:textInputIsDuplicate>{msg} {textInputIsDuplicate ? '🤦' : '👷'}</span>
+  <span slot="user-msg" let:msg>{msg} {selected?.includes(searchText) ? '🤦' : '👷'}</span>
 </MultiSelect>
 ```

--- a/src/routes/(demos)/ui/+page.svx
+++ b/src/routes/(demos)/ui/+page.svx
@@ -20,7 +20,7 @@
   options={foods.map(label => ({ label, style: `background-color: ${random_color()}` }))}
   placeholder="Pick your favorite foods"
   removeAllTitle="Remove all foods"
-  focusInputOnSelect={false}
+  closeDropdownOnSelect={true}
   invalid
 />
 ```
@@ -44,7 +44,7 @@ This page is used for Playwright testing to ensure
   - has `aria-expanded='true'` when open
   - options have `aria-selected='false'` and selected items have `aria-selected='true`
   - invisible `input.form-control` is `aria-hidden`
-- `focusInputOnSelect`: when `false`, the input is not focused when an option is selected and the dropdown is closed
+- `closeDropdownOnSelect`: when `true`, the input is not focused when an option is selected and the dropdown is closed
 
 <!-- TODO figure out why Playwright test 'loops through the dropdown list with arrow keys making...'
 depends on `html { scroll-behavior: smooth; }` -->

--- a/src/routes/(demos)/ui/+page.svx
+++ b/src/routes/(demos)/ui/+page.svx
@@ -20,6 +20,7 @@
   options={foods.map(label => ({ label, style: `background-color: ${random_color()}` }))}
   placeholder="Pick your favorite foods"
   removeAllTitle="Remove all foods"
+  focusInputOnSelect={false}
   invalid
 />
 ```
@@ -43,6 +44,7 @@ This page is used for Playwright testing to ensure
   - has `aria-expanded='true'` when open
   - options have `aria-selected='false'` and selected items have `aria-selected='true`
   - invisible `input.form-control` is `aria-hidden`
+- `focusInputOnSelect`: when `false`, the input is not focused when an option is selected and the dropdown is closed
 
 <!-- TODO figure out why Playwright test 'loops through the dropdown list with arrow keys making...'
 depends on `html { scroll-behavior: smooth; }` -->

--- a/tests/unit/MultiSelect.test.ts
+++ b/tests/unit/MultiSelect.test.ts
@@ -1288,11 +1288,11 @@ test.each([
 )
 
 test.each([true, false, `desktop`] as const)(
-  `focusInputOnSelect=%s controls input focus and dropdown closing`,
-  async (focusInputOnSelect) => {
+  `closeDropdownOnSelect=%s controls input focus and dropdown closing`,
+  async (closeDropdownOnSelect) => {
     const select = new MultiSelect({
       target: document.body,
-      props: { options: [1, 2, 3], focusInputOnSelect },
+      props: { options: [1, 2, 3], closeDropdownOnSelect },
     })
 
     // simulate selecting an option
@@ -1302,20 +1302,19 @@ test.each([true, false, `desktop`] as const)(
     await tick() // wait for DOM updates
 
     const is_desktop = window.innerWidth > select.breakpoint
-    const should_be_focused =
-      focusInputOnSelect === true ||
-      (focusInputOnSelect === `desktop` && is_desktop)
+    const should_be_closed =
+      closeDropdownOnSelect === true ||
+      (closeDropdownOnSelect === `desktop` && !is_desktop)
+
+    // check that dropdown is closed when closeDropdownOnSelect = false
+    const dropdown = doc_query(`ul.options`)
+    expect(dropdown.classList.contains(`hidden`)).toBe(should_be_closed)
 
     // check that input is focused (or not)
     const input = doc_query<HTMLInputElement>(`input[autocomplete]`)
-    expect(document.activeElement === input).toBe(should_be_focused)
+    expect(document.activeElement === input).toBe(!should_be_closed)
 
-    // check that dropdown is closed when focusInputOnSelect = false
-    const dropdown = doc_query(`ul.options`)
-    const should_be_closed = focusInputOnSelect === false
-    expect(dropdown.classList.contains(`hidden`)).toBe(should_be_closed)
-
-    if (focusInputOnSelect === `desktop`) {
+    if (closeDropdownOnSelect === `desktop`) {
       // reduce window width to simulate mobile
       window.innerWidth = 400
       window.dispatchEvent(new Event(`resize`))


### PR DESCRIPTION
Closes #264.

The new `closeDropdownOnSelect` is essentially the boolean inverse of `focusInputOnSelect` but also controls whether the dropdown is closed on item selection.

6534d1d improve readme docs on `'after-input'` slot
5e03954 improve `'user-msg'` slot readme docs
dc7662c fix `msgType` type
68cf526 fix `"user-msg"` slot demo
535a73f close dropdown when `focusInputOnSelect = false`
2af971e add test 'focusInputOnSelect=%s controls input focus and dropdown closing'
7b2565c update `focusInputOnSelect` readme docs to include dropdown closing
aefc03a breaking: rename `focusInputOnSelect` to `closeDropdownOnSelect`