### PR TITLE
bump svelte version to the last supported 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "update-coverage": "vitest tests/unit --run --coverage && npx istanbul-badges-readme"
   },
   "dependencies": {
-    "svelte": "4.2.12"
+    "svelte": "4.2.19"
   },
   "devDependencies": {
     "@iconify/svelte": "^4.0.2",


### PR DESCRIPTION
Hello,
Just a quick PR to help with the mXSS security warning that got fixed on svelte 4.2.19.
Probably will be replaced once moved to svelte 5.
Thank you