### PR TITLE
MultiSelect fire `oncreate` event for all user-created options

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -232,8 +232,9 @@
           } else {
             option_to_add = searchText as Option // else create custom option as string
           }
-          oncreate?.({ option: option_to_add })
         }
+        // Fire oncreate event for all user-created options, regardless of type
+        oncreate?.({ option: option_to_add })
         if (allowUserOptions === `append`) options = [...options, option_to_add]
       }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,7 +45,7 @@ export interface MultiSelectNativeEvents {
 // custom events created by MultiSelect
 export interface MultiSelectEvents<T extends Option = Option> {
   onadd?: (data: { option: T }) => unknown
-  oncreate?: (data: { option: T }) => unknown
+  oncreate?: (data: { option: T }) => unknown // fires when users entered custom text from which new option is created
   onremove?: (data: { option: T }) => unknown
   onremoveAll?: (data: { options: T[] }) => unknown
   onchange?: (data: {


### PR DESCRIPTION
- update `oncreate` event in MultiSelect to trigger for all user-created options (now consistent behavior across different option types)
- unit tests to verify correct payload for `oncreate` event (covering string, number, and object cases)

Closes #263.