### PR TITLE
Add fallback for crypto.randomUUID to prevent crash in non-secure contexts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
     with:
       deno-version: 2.3.7
       node-version: '22'
-      test-cmd: NODE_OPTIONS="--experimental-strip-types" npx vitest --run
+      test-cmd: NODE_OPTIONS=--experimental-strip-types npx vitest --run
       e2e-install-cmd: npx playwright install chromium
       e2e-test-cmd: npx playwright test

--- a/package.json
+++ b/package.json
@@ -22,28 +22,28 @@
     "svelte": "^5.35.6"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
-    "@stylistic/eslint-plugin": "^5.7.0",
+    "@playwright/test": "^1.58.0",
+    "@stylistic/eslint-plugin": "^5.7.1",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.50.0",
+    "@sveltejs/kit": "^2.50.1",
     "@sveltejs/package": "2.5.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
-    "@types/node": "^25.0.9",
-    "@vitest/coverage-v8": "^4.0.17",
+    "@types/node": "^25.0.10",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",
     "eslint-plugin-svelte": "^3.14.0",
-    "happy-dom": "^20.3.1",
+    "happy-dom": "^20.3.7",
     "mdsvex": "^0.12.6",
     "mdsvexamples": "^0.5.1",
-    "svelte": "^5.46.4",
+    "svelte": "^5.48.0",
     "svelte-check": "^4.3.5",
     "svelte-preprocess": "^6.0.3",
     "svelte-toc": "^0.6.2",
     "svelte2tsx": "^0.7.46",
     "typescript": "5.9.3",
-    "typescript-eslint": "^8.53.0",
+    "typescript-eslint": "^8.53.1",
     "vite": "^7.3.1",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.18"
   },
   "keywords": [
     "svelte",
@@ -69,6 +69,10 @@
     "./attachments": {
       "types": "./dist/attachments.d.ts",
       "default": "./dist/attachments.js"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "default": "./dist/utils.js"
     },
     "./heading-anchors": {
       "types": "./dist/heading-anchors.d.ts",

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,15 +1,28 @@
 <!-- eslint-disable-next-line @stylistic/quotes -- TS generics require string literals -->
 <script lang="ts" generics="Option extends import('./types').Option">
-  import { tick, untrack } from 'svelte'
-  import { flip } from 'svelte/animate'
-  import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
-  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
-  import { highlight_matches } from './attachments'
-  import CircleSpinner from './CircleSpinner.svelte'
-  import Icon from './Icon.svelte'
-  import type { GroupedOptions, KeyboardShortcuts, MultiSelectProps } from './types'
-  import { fuzzy_match, get_label, get_style, has_group, is_object } from './utils'
-  import Wiggle from './Wiggle.svelte'
+  import { tick, untrack } from "svelte";
+  import { flip } from "svelte/animate";
+  import type {
+    FocusEventHandler,
+    KeyboardEventHandler,
+  } from "svelte/elements";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
+  import { highlight_matches, get_uuid } from "./attachments";
+  import CircleSpinner from "./CircleSpinner.svelte";
+  import Icon from "./Icon.svelte";
+  import type {
+    GroupedOptions,
+    KeyboardShortcuts,
+    MultiSelectProps,
+  } from "./types";
+  import {
+    fuzzy_match,
+    get_label,
+    get_style,
+    has_group,
+    is_object,
+  } from "./utils";
+  import Wiggle from "./Wiggle.svelte";
 
   let {
     activeIndex = $bindable(null),
@@ -28,11 +41,11 @@
     keepSelectedInDropdown = false,
     key = (opt) => `${get_label(opt)}`.toLowerCase(),
     filterFunc = (opt, searchText) => {
-      if (!searchText) return true
-      const label = `${get_label(opt)}`
+      if (!searchText) return true;
+      const label = `${get_label(opt)}`;
       return fuzzy
         ? fuzzy_match(searchText, label)
-        : label.toLowerCase().includes(searchText.toLowerCase())
+        : label.toLowerCase().includes(searchText.toLowerCase());
     },
     fuzzy = true,
     closeDropdownOnSelect = false,
@@ -75,12 +88,15 @@
     value = $bindable(null),
     selected = $bindable(
       value !== null && value !== undefined
-        ? (Array.isArray(value) ? value : [value])
+        ? Array.isArray(value)
+          ? value
+          : [value]
         : (options
-          ?.filter((opt) =>
-            typeof opt === `object` && opt !== null && opt?.preselected
-          )
-          .slice(0, maxSelect ?? undefined) ?? []),
+            ?.filter(
+              (opt) =>
+                typeof opt === `object` && opt !== null && opt?.preselected,
+            )
+            .slice(0, maxSelect ?? undefined) ?? []),
     ),
     sortSelected = false,
     selectedOptionsDraggable = !sortSelected,
@@ -152,48 +168,55 @@
     // Keyboard shortcuts for common actions
     shortcuts = {},
     ...rest
-  }: MultiSelectProps<Option> = $props()
+  }: MultiSelectProps<Option> = $props();
 
   // Generate unique IDs for ARIA associations (combobox pattern)
   // Uses provided id prop or generates a random one using crypto API
-  const internal_id = $derived(id ?? `sms-${crypto.randomUUID().slice(0, 8)}`)
-  const listbox_id = $derived(`${internal_id}-listbox`)
+  const internal_id = $derived(id ?? `sms-${get_uuid().slice(0, 8)}`);
+  const listbox_id = $derived(`${internal_id}-listbox`);
 
   // Parse shortcut string into modifier+key parts
   function parse_shortcut(shortcut: string): {
-    key: string
-    ctrl: boolean
-    shift: boolean
-    alt: boolean
-    meta: boolean
+    key: string;
+    ctrl: boolean;
+    shift: boolean;
+    alt: boolean;
+    meta: boolean;
   } {
-    const parts = shortcut.toLowerCase().split(`+`).map((part) => part.trim())
-    const key = parts.pop() ?? ``
+    const parts = shortcut
+      .toLowerCase()
+      .split(`+`)
+      .map((part) => part.trim());
+    const key = parts.pop() ?? ``;
     return {
       key,
       ctrl: parts.includes(`ctrl`),
       shift: parts.includes(`shift`),
       alt: parts.includes(`alt`),
       meta: parts.includes(`meta`) || parts.includes(`cmd`),
-    }
+    };
   }
 
   function matches_shortcut(
     event: KeyboardEvent,
     shortcut: string | null | undefined,
   ): boolean {
-    if (!shortcut) return false
-    const parsed = parse_shortcut(shortcut)
+    if (!shortcut) return false;
+    const parsed = parse_shortcut(shortcut);
     // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
-    if (!parsed.key) return false
-    const key_matches = event.key.toLowerCase() === parsed.key
-    const ctrl_matches = event.ctrlKey === parsed.ctrl
-    const shift_matches = event.shiftKey === parsed.shift
-    const alt_matches = event.altKey === parsed.alt
-    const meta_matches = event.metaKey === parsed.meta
+    if (!parsed.key) return false;
+    const key_matches = event.key.toLowerCase() === parsed.key;
+    const ctrl_matches = event.ctrlKey === parsed.ctrl;
+    const shift_matches = event.shiftKey === parsed.shift;
+    const alt_matches = event.altKey === parsed.alt;
+    const meta_matches = event.metaKey === parsed.meta;
     return (
-      key_matches && ctrl_matches && shift_matches && alt_matches && meta_matches
-    )
+      key_matches &&
+      ctrl_matches &&
+      shift_matches &&
+      alt_matches &&
+      meta_matches
+    );
   }
 
   // Default shortcuts
@@ -202,110 +225,132 @@
     clear_all: `ctrl+shift+a`,
     open: null,
     close: null,
-  }
+  };
 
   const effective_shortcuts = $derived({
     ...default_shortcuts,
     ...shortcuts,
-  })
+  });
 
   // Extract loadOptions config into single derived object (supports both simple function and config object)
   const load_options_config = $derived.by(() => {
-    if (!loadOptions) return null
-    const is_fn = typeof loadOptions === `function`
+    if (!loadOptions) return null;
+    const is_fn = typeof loadOptions === `function`;
     return {
       fetch: is_fn ? loadOptions : loadOptions.fetch,
       debounce_ms: is_fn ? 300 : (loadOptions.debounceMs ?? 300),
       batch_size: is_fn ? 50 : (loadOptions.batchSize ?? 50),
       on_open: is_fn ? true : (loadOptions.onOpen ?? true),
-    }
-  })
+    };
+  });
 
   // Helper to compare arrays/values for equality to avoid unnecessary updates.
   // Prevents infinite loops when value/selected are bound to reactive wrappers
   // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
   // Treats null/undefined/[] as equivalent empty states to prevent extra updates on init (#369).
   function values_equal(val1: unknown, val2: unknown): boolean {
-    if (val1 === val2) return true
-    const empty1 = val1 == null || (Array.isArray(val1) && val1.length === 0)
-    const empty2 = val2 == null || (Array.isArray(val2) && val2.length === 0)
-    if (empty1 && empty2) return true
+    if (val1 === val2) return true;
+    const empty1 = val1 == null || (Array.isArray(val1) && val1.length === 0);
+    const empty2 = val2 == null || (Array.isArray(val2) && val2.length === 0);
+    if (empty1 && empty2) return true;
     if (Array.isArray(val1) && Array.isArray(val2)) {
-      return val1.length === val2.length &&
+      return (
+        val1.length === val2.length &&
         val1.every((item, idx) => item === val2[idx])
+      );
     }
-    return false
+    return false;
   }
 
   // Sync selected ↔ value bidirectionally. Use untrack to prevent each effect from
   // reacting to changes in the "destination" value, and values_equal to prevent
   // infinite loops with reactive wrappers that clone arrays. See issue #309.
   $effect.pre(() => {
-    const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected
-    if (!values_equal(untrack(() => value), new_value)) value = new_value
-  })
+    const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected;
+    if (
+      !values_equal(
+        untrack(() => value),
+        new_value,
+      )
+    )
+      value = new_value;
+  });
   $effect.pre(() => {
-    const new_selected = maxSelect === 1
-      ? (value ? [value as Option] : [])
-      : (Array.isArray(value) ? value : [])
-    if (!values_equal(untrack(() => selected), new_selected)) selected = new_selected
-  })
+    const new_selected =
+      maxSelect === 1
+        ? value
+          ? [value as Option]
+          : []
+        : Array.isArray(value)
+          ? value
+          : [];
+    if (
+      !values_equal(
+        untrack(() => selected),
+        new_selected,
+      )
+    )
+      selected = new_selected;
+  });
 
-  let wiggle = $state(false) // controls wiggle animation when user tries to exceed maxSelect
-  let ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
+  let wiggle = $state(false); // controls wiggle animation when user tries to exceed maxSelect
+  let ignore_hover = $state(false); // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
 
   // Track last selection action for aria-live announcements
-  let last_action = $state<
-    { type: `add` | `remove` | `removeAll`; label: string } | null
-  >(null)
+  let last_action = $state<{
+    type: `add` | `remove` | `removeAll`;
+    label: string;
+  } | null>(null);
 
   // Clear last_action after announcement so option counts can be announced again
   $effect(() => {
     if (last_action) {
-      const timer = setTimeout(() => (last_action = null), 1000)
-      return () => clearTimeout(timer)
+      const timer = setTimeout(() => (last_action = null), 1000);
+      return () => clearTimeout(timer);
     }
-  })
+  });
 
   // Debounced onsearch event - fires 150ms after search text stops changing
-  let search_debounce_timer: ReturnType<typeof setTimeout> | null = null
-  let search_initialized = false
+  let search_debounce_timer: ReturnType<typeof setTimeout> | null = null;
+  let search_initialized = false;
   $effect(() => {
-    const current_search = searchText
+    const current_search = searchText;
     // Skip initial mount - only fire on actual user input
     if (!search_initialized) {
-      search_initialized = true
-      return
+      search_initialized = true;
+      return;
     }
-    if (!onsearch) return // cleanup handles any pending timer
+    if (!onsearch) return; // cleanup handles any pending timer
 
     search_debounce_timer = setTimeout(() => {
       // Optional chaining in case onsearch is removed while timer is pending
       onsearch?.({
         searchText: current_search,
         matchingCount: matchingOptions.length,
-      })
-    }, 150)
+      });
+    }, 150);
     return () => {
-      if (search_debounce_timer) clearTimeout(search_debounce_timer)
-    }
-  })
+      if (search_debounce_timer) clearTimeout(search_debounce_timer);
+    };
+  });
 
   // Internal state for loadOptions feature (null = never loaded)
-  let loaded_options = $state<Option[]>([])
-  let load_options_has_more = $state(true)
-  let load_options_loading = $state(false)
-  let load_options_last_search: string | null = $state(null)
-  let debounce_timer: ReturnType<typeof setTimeout> | null = null
+  let loaded_options = $state<Option[]>([]);
+  let load_options_has_more = $state(true);
+  let load_options_loading = $state(false);
+  let load_options_last_search: string | null = $state(null);
+  let debounce_timer: ReturnType<typeof setTimeout> | null = null;
 
-  let effective_options = $derived(loadOptions ? loaded_options : (options ?? []))
+  let effective_options = $derived(
+    loadOptions ? loaded_options : (options ?? []),
+  );
 
   // Cache selected keys and labels to avoid repeated .map() calls
-  let selected_keys = $derived(selected.map(key))
-  let selected_labels = $derived(selected.map(get_label))
+  let selected_keys = $derived(selected.map(key));
+  let selected_labels = $derived(selected.map(get_label));
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
-  let selected_keys_set = $derived(new Set(selected_keys))
-  let selected_labels_set = $derived(new Set(selected_labels))
+  let selected_keys_set = $derived(new Set(selected_keys));
+  let selected_labels_set = $derived(new Set(selected_labels));
 
   // Memoized Set of disabled option keys for O(1) lookups in large option sets
   let disabled_option_keys = $derived(
@@ -314,25 +359,25 @@
         .filter((opt) => is_object(opt) && opt.disabled)
         .map(key),
     ),
-  )
+  );
 
   // Check if an option is disabled (uses memoized Set for O(1) lookup)
-  const is_disabled = (opt: Option) => disabled_option_keys.has(key(opt))
+  const is_disabled = (opt: Option) => disabled_option_keys.has(key(opt));
 
   // Group matching options by their `group` key
   // Note: SvelteMap used here to satisfy eslint svelte/prefer-svelte-reactivity rule,
   // though a plain Map would work since this is recreated fresh on each derivation
   let grouped_options = $derived.by((): GroupedOptions<Option>[] => {
-    const groups_map = new SvelteMap<string, Option[]>()
-    const ungrouped: Option[] = []
+    const groups_map = new SvelteMap<string, Option[]>();
+    const ungrouped: Option[] = [];
 
     for (const opt of matchingOptions) {
       if (has_group(opt)) {
-        const existing = groups_map.get(opt.group)
-        if (existing) existing.push(opt)
-        else groups_map.set(opt.group, [opt])
+        const existing = groups_map.get(opt.group);
+        if (existing) existing.push(opt);
+        else groups_map.set(opt.group, [opt]);
       } else {
-        ungrouped.push(opt)
+        ungrouped.push(opt);
       }
     }
 
@@ -340,180 +385,186 @@
       group,
       options,
       collapsed: collapsedGroups.has(group),
-    }))
+    }));
 
     // Apply group sorting if specified
     if (groupSortOrder && groupSortOrder !== `none`) {
       grouped = grouped.toSorted((group_a, group_b) => {
         if (typeof groupSortOrder === `function`) {
-          return groupSortOrder(group_a.group, group_b.group)
+          return groupSortOrder(group_a.group, group_b.group);
         }
-        const cmp = group_a.group.localeCompare(group_b.group)
-        return groupSortOrder === `desc` ? -cmp : cmp
-      })
+        const cmp = group_a.group.localeCompare(group_b.group);
+        return groupSortOrder === `desc` ? -cmp : cmp;
+      });
     }
 
-    if (ungrouped.length === 0) return grouped
+    if (ungrouped.length === 0) return grouped;
 
-    const ungrouped_entry = { group: null, options: ungrouped, collapsed: false }
+    const ungrouped_entry = {
+      group: null,
+      options: ungrouped,
+      collapsed: false,
+    };
     return ungroupedPosition === `first`
       ? [ungrouped_entry, ...grouped]
-      : [...grouped, ungrouped_entry]
-  })
+      : [...grouped, ungrouped_entry];
+  });
 
   // Flattened options for navigation (excludes options in collapsed groups)
   let navigable_options = $derived(
     grouped_options.flatMap(({ options: group_opts, collapsed }) =>
-      collapsed && collapsibleGroups ? [] : group_opts
+      collapsed && collapsibleGroups ? [] : group_opts,
     ),
-  )
+  );
 
   // Pre-computed Map for O(1) index lookups (avoids O(n²) in template)
   let navigable_index_map = $derived(
     new Map(navigable_options.map((opt, idx) => [opt, idx])),
-  )
+  );
 
   // Pre-computed group header state (avoids repeated calculations in template)
-  type GroupHeaderState = { all_selected: boolean; selected_count: number }
+  type GroupHeaderState = { all_selected: boolean; selected_count: number };
   let group_header_state = $derived.by(() => {
-    const state = new SvelteMap<string, GroupHeaderState>()
+    const state = new SvelteMap<string, GroupHeaderState>();
     for (const { group, options: opts, collapsed } of grouped_options) {
-      if (group === null) continue
-      const selectable = get_selectable_opts(opts, collapsed)
-      const all_selected = selectable.length > 0 &&
-        selectable.every((opt) => selected_keys_set.has(key(opt)))
+      if (group === null) continue;
+      const selectable = get_selectable_opts(opts, collapsed);
+      const all_selected =
+        selectable.length > 0 &&
+        selectable.every((opt) => selected_keys_set.has(key(opt)));
       // Count selected options (only needed when keepSelectedInDropdown is enabled)
-      let selected_count = 0
+      let selected_count = 0;
       if (keepSelectedInDropdown) {
         for (const opt of opts) {
-          if (selected_keys_set.has(key(opt))) selected_count++
+          if (selected_keys_set.has(key(opt))) selected_count++;
         }
       }
-      state.set(group, { all_selected, selected_count })
+      state.set(group, { all_selected, selected_count });
     }
-    return state
-  })
+    return state;
+  });
 
   // Update collapsedGroups state: 'add' adds groups, 'delete' removes groups, 'set' replaces all
   function update_collapsed_groups(
     action: `add` | `delete` | `set`,
     groups: string | Iterable<string>,
   ) {
-    const items = typeof groups === `string` ? [groups] : [...groups]
-    if (action === `set`) collapsedGroups = new SvelteSet(items)
+    const items = typeof groups === `string` ? [groups] : [...groups];
+    if (action === `set`) collapsedGroups = new SvelteSet(items);
     else {
-      const updated = new SvelteSet(collapsedGroups)
-      for (const group of items) updated[action](group)
-      collapsedGroups = updated
+      const updated = new SvelteSet(collapsedGroups);
+      for (const group of items) updated[action](group);
+      collapsedGroups = updated;
     }
   }
 
   // Toggle group collapsed state
   function toggle_group_collapsed(group_name: string) {
-    const was_collapsed = collapsedGroups.has(group_name)
-    update_collapsed_groups(was_collapsed ? `delete` : `add`, group_name)
-    ongroupToggle?.({ group: group_name, collapsed: !was_collapsed })
+    const was_collapsed = collapsedGroups.has(group_name);
+    update_collapsed_groups(was_collapsed ? `delete` : `add`, group_name);
+    ongroupToggle?.({ group: group_name, collapsed: !was_collapsed });
   }
 
   // Collapse/expand all groups (exposed via bindable props)
   collapseAllGroups = () => {
     const groups = grouped_options
       .map((entry) => entry.group)
-      .filter((group_name): group_name is string => group_name !== null)
-    if (groups.length === 0) return
-    update_collapsed_groups(`set`, groups)
-    oncollapseAll?.({ groups })
-  }
+      .filter((group_name): group_name is string => group_name !== null);
+    if (groups.length === 0) return;
+    update_collapsed_groups(`set`, groups);
+    oncollapseAll?.({ groups });
+  };
   expandAllGroups = () => {
-    const groups = [...collapsedGroups]
-    if (groups.length === 0) return
-    update_collapsed_groups(`set`, [])
-    onexpandAll?.({ groups })
-  }
+    const groups = [...collapsedGroups];
+    if (groups.length === 0) return;
+    update_collapsed_groups(`set`, []);
+    onexpandAll?.({ groups });
+  };
 
   // Expand specified groups and fire ongroupToggle for each
   function expand_groups(groups_to_expand: string[]) {
-    if (groups_to_expand.length === 0) return
-    update_collapsed_groups(`delete`, groups_to_expand)
-    for (const group of groups_to_expand) ongroupToggle?.({ group, collapsed: false })
+    if (groups_to_expand.length === 0) return;
+    update_collapsed_groups(`delete`, groups_to_expand);
+    for (const group of groups_to_expand)
+      ongroupToggle?.({ group, collapsed: false });
   }
 
   // Get names of collapsed groups that have matching options
   const get_collapsed_with_matches = () =>
     grouped_options.flatMap(({ group, collapsed, options: opts }) =>
-      group && collapsed && opts.length > 0 ? [group] : []
-    )
+      group && collapsed && opts.length > 0 ? [group] : [],
+    );
 
   // Auto-expand collapsed groups when search matches their options
   $effect(() => {
     if (searchExpandsCollapsedGroups && searchText && collapsibleGroups) {
-      expand_groups(get_collapsed_with_matches())
+      expand_groups(get_collapsed_with_matches());
     }
-  })
+  });
 
   // Normalize placeholder prop (supports string or { text, persistent } object)
   const placeholder_text = $derived(
-    typeof placeholder === `string` ? placeholder : placeholder?.text ?? null,
-  )
+    typeof placeholder === `string` ? placeholder : (placeholder?.text ?? null),
+  );
   const placeholder_persistent = $derived(
     typeof placeholder === `object` && placeholder?.persistent === true,
-  )
+  );
 
   // Helper to sort selected options (used by add() and select_all())
   function sort_selected(items: Option[]): Option[] {
     if (sortSelected === true) {
       return items.toSorted((op1, op2) =>
-        `${get_label(op1)}`.localeCompare(`${get_label(op2)}`)
-      )
+        `${get_label(op1)}`.localeCompare(`${get_label(op2)}`),
+      );
     } else if (typeof sortSelected === `function`) {
-      return items.toSorted(sortSelected)
+      return items.toSorted(sortSelected);
     }
-    return items
+    return items;
   }
 
   untrack(() => {
     if (!loadOptions && !((options?.length ?? 0) > 0)) {
       if (allowUserOptions || loading || disabled || allowEmpty) {
-        options = [] // initializing as array avoids errors when component mounts
+        options = []; // initializing as array avoids errors when component mounts
       } else {
         // error on empty options if user is not allowed to create custom options and loading is false
         // and component is not disabled and allowEmpty is false
-        console.error(`MultiSelect: received no options`)
+        console.error(`MultiSelect: received no options`);
       }
     }
-  })
+  });
   if (maxSelect !== null && maxSelect < 1) {
     console.error(
       `MultiSelect: maxSelect must be null or positive integer, got ${maxSelect}`,
-    )
+    );
   }
   if (!Array.isArray(selected)) {
     console.error(
       `MultiSelect: selected prop should always be an array, got ${selected}`,
-    )
+    );
   }
   $effect(() => {
     if (maxSelect && typeof required === `number` && required > maxSelect) {
       console.error(
         `MultiSelect: maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`,
-      )
+      );
     }
     if (parseLabelsAsHtml && allowUserOptions) {
       console.warn(
         `MultiSelect: don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`,
-      )
+      );
     }
     if (sortSelected && selectedOptionsDraggable) {
       console.warn(
         `MultiSelect: sortSelected and selectedOptionsDraggable should not be combined as any ` +
           `user re-orderings of selected options will be undone by sortSelected on component re-renders.`,
-      )
+      );
     }
     if (allowUserOptions && !createOptionMsg && createOptionMsg !== null) {
       console.error(
         `MultiSelect: allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
           `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`,
-      )
+      );
     }
     if (
       maxOptions &&
@@ -521,87 +572,91 @@
     ) {
       console.error(
         `MultiSelect: maxOptions must be undefined or a positive integer, got ${maxOptions}`,
-      )
+      );
     }
-  })
+  });
 
-  let option_msg_is_active = $state(false) // controls active state of <li>{createOptionMsg}</li>
-  let window_width = $state(0)
+  let option_msg_is_active = $state(false); // controls active state of <li>{createOptionMsg}</li>
+  let window_width = $state(0);
 
   // Check if option matches search text (label or optionally group name)
   const matches_search = (opt: Option, search: string): boolean => {
-    if (filterFunc(opt, search)) return true
+    if (filterFunc(opt, search)) return true;
     if (searchMatchesGroups && search && has_group(opt)) {
       return fuzzy
         ? fuzzy_match(search, opt.group)
-        : opt.group.toLowerCase().includes(search.toLowerCase())
+        : opt.group.toLowerCase().includes(search.toLowerCase());
     }
-    return false
-  }
+    return false;
+  };
 
   $effect.pre(() => {
     // When using loadOptions, server handles filtering, so skip client-side filterFunc
     matchingOptions = effective_options.filter((opt) => {
       // Check if option is already selected and should be excluded
-      const keep_in_list = !selected_keys_set.has(key(opt)) ||
+      const keep_in_list =
+        !selected_keys_set.has(key(opt)) ||
         duplicates ||
-        keepSelectedInDropdown
-      if (!keep_in_list) return false
+        keepSelectedInDropdown;
+      if (!keep_in_list) return false;
 
       // When using loadOptions, server handles filtering; otherwise check search match
-      return loadOptions || matches_search(opt, searchText)
-    })
-  })
+      return loadOptions || matches_search(opt, searchText);
+    });
+  });
 
   // reset activeIndex if out of bounds (can happen when options change while dropdown is open)
   $effect(() => {
     if (activeIndex !== null && !navigable_options[activeIndex]) {
-      activeIndex = null
+      activeIndex = null;
     }
-  })
+  });
 
   // update activeOption when activeIndex changes
   $effect(() => {
-    activeOption = navigable_options[activeIndex ?? -1] ?? null
-  })
+    activeOption = navigable_options[activeIndex ?? -1] ?? null;
+  });
 
   // Compute the ID of the currently active option for aria-activedescendant
   const active_option_id = $derived(
     activeIndex !== null && activeIndex < navigable_options.length
       ? `${internal_id}-opt-${activeIndex}`
       : undefined,
-  )
+  );
 
   // Helper to check if removing an option would violate minSelect constraint
-  const can_remove = $derived(minSelect === null || selected.length > minSelect)
+  const can_remove = $derived(
+    minSelect === null || selected.length > minSelect,
+  );
 
   // toggle an option between selected and unselected states (for keepSelectedInDropdown mode)
   function toggle_option(option_to_toggle: Option, event: Event) {
-    const is_currently_selected = selected_keys_set.has(key(option_to_toggle))
+    const is_currently_selected = selected_keys_set.has(key(option_to_toggle));
 
     if (is_currently_selected) {
-      if (can_remove) remove(option_to_toggle, event)
-    } else add(option_to_toggle, event)
+      if (can_remove) remove(option_to_toggle, event);
+    } else add(option_to_toggle, event);
   }
 
   // add an option to selected list
   function add(option_to_add: Option, event: Event) {
-    event.stopPropagation()
-    if (maxSelect !== null && selected.length >= maxSelect) wiggle = true
+    event.stopPropagation();
+    if (maxSelect !== null && selected.length >= maxSelect) wiggle = true;
     if (
-      !isNaN(Number(option_to_add)) && typeof selected_labels[0] === `number`
+      !isNaN(Number(option_to_add)) &&
+      typeof selected_labels[0] === `number`
     ) {
-      option_to_add = Number(option_to_add) as Option // convert to number if possible
+      option_to_add = Number(option_to_add) as Option; // convert to number if possible
     }
 
-    const is_duplicate = selected_keys_set.has(key(option_to_add))
-    const max_reached = maxSelect !== null && maxSelect !== 1 &&
-      selected.length >= maxSelect
+    const is_duplicate = selected_keys_set.has(key(option_to_add));
+    const max_reached =
+      maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect;
     // Fire events for blocked add attempts
     if (max_reached) {
-      onmaxreached?.({ selected, maxSelect, attemptedOption: option_to_add })
+      onmaxreached?.({ selected, maxSelect, attemptedOption: option_to_add });
     }
-    if (is_duplicate && !duplicates) onduplicate?.({ option: option_to_add })
+    if (is_duplicate && !duplicates) onduplicate?.({ option: option_to_add });
 
     if (
       (maxSelect === null || maxSelect === 1 || selected.length < maxSelect) &&
@@ -618,181 +673,193 @@
         // a new option from the user-entered text
         if (typeof effective_options[0] === `object`) {
           // if 1st option is an object, we create new option as object to keep type homogeneity
-          option_to_add = { label: searchText } as Option
+          option_to_add = { label: searchText } as Option;
         } else {
           if (
             [`number`, `undefined`].includes(typeof effective_options[0]) &&
             !isNaN(Number(searchText))
           ) {
             // create new option as number if it parses to a number and 1st option is also number or missing
-            option_to_add = Number(searchText) as Option
+            option_to_add = Number(searchText) as Option;
           } else {
-            option_to_add = searchText as Option // else create custom option as string
+            option_to_add = searchText as Option; // else create custom option as string
           }
         }
         // Fire oncreate event for all user-created options, regardless of type
-        oncreate?.({ option: option_to_add })
+        oncreate?.({ option: option_to_add });
         if (allowUserOptions === `append`) {
           if (loadOptions) {
-            loaded_options = [...loaded_options, option_to_add]
+            loaded_options = [...loaded_options, option_to_add];
           } else {
-            options = [...(options ?? []), option_to_add]
+            options = [...(options ?? []), option_to_add];
           }
         }
       }
 
-      if (resetFilterOnAdd) searchText = `` // reset search string on selection
+      if (resetFilterOnAdd) searchText = ``; // reset search string on selection
       if ([``, undefined, null].includes(option_to_add as string | null)) {
-        console.error(`MultiSelect: encountered falsy option`, option_to_add)
-        return
+        console.error(`MultiSelect: encountered falsy option`, option_to_add);
+        return;
       }
       // for maxSelect = 1 we always replace current option with new one
-      if (maxSelect === 1) selected = [option_to_add]
+      if (maxSelect === 1) selected = [option_to_add];
       else {
-        selected = sort_selected([...selected, option_to_add])
+        selected = sort_selected([...selected, option_to_add]);
       }
 
-      clear_validity()
-      handle_dropdown_after_select(event)
-      last_action = { type: `add`, label: `${get_label(option_to_add)}` }
-      onadd?.({ option: option_to_add })
-      onchange?.({ option: option_to_add, type: `add` })
+      clear_validity();
+      handle_dropdown_after_select(event);
+      last_action = { type: `add`, label: `${get_label(option_to_add)}` };
+      onadd?.({ option: option_to_add });
+      onchange?.({ option: option_to_add, type: `add` });
     }
   }
 
   // remove an option from selected list
   function remove(option_to_drop: Option, event: Event) {
-    event.stopPropagation()
-    if (selected.length === 0) return
+    event.stopPropagation();
+    if (selected.length === 0) return;
 
-    const idx = selected.findIndex((opt) => key(opt) === key(option_to_drop))
-    let option_removed = selected[idx]
+    const idx = selected.findIndex((opt) => key(opt) === key(option_to_drop));
+    let option_removed = selected[idx];
 
     if (option_removed === undefined && allowUserOptions) {
       // if option with label could not be found but allowUserOptions is truthy,
       // assume it was created by user and create corresponding option object
       // on the fly for use as event payload
-      const is_object_option = typeof effective_options[0] === `object`
+      const is_object_option = typeof effective_options[0] === `object`;
       option_removed = (
         is_object_option ? { label: option_to_drop } : option_to_drop
-      ) as Option
+      ) as Option;
     }
     if (option_removed === undefined) {
       console.error(
-        `MultiSelect: can't remove option ${
-          JSON.stringify(option_to_drop)
-        }, not found in selected list`,
-      )
-      return
+        `MultiSelect: can't remove option ${JSON.stringify(
+          option_to_drop,
+        )}, not found in selected list`,
+      );
+      return;
     }
 
-    selected = selected.filter((_, remove_idx) => remove_idx !== idx)
-    clear_validity()
-    last_action = { type: `remove`, label: `${get_label(option_removed)}` }
-    onremove?.({ option: option_removed })
-    onchange?.({ option: option_removed, type: `remove` })
+    selected = selected.filter((_, remove_idx) => remove_idx !== idx);
+    clear_validity();
+    last_action = { type: `remove`, label: `${get_label(option_removed)}` };
+    onremove?.({ option: option_removed });
+    onchange?.({ option: option_removed, type: `remove` });
   }
 
   function open_dropdown(event: Event) {
-    event.stopPropagation()
+    event.stopPropagation();
 
-    if (disabled) return
-    open = true
+    if (disabled) return;
+    open = true;
     if (!(event instanceof FocusEvent)) {
       // avoid double-focussing input when event that opened dropdown was already input FocusEvent
-      input?.focus()
+      input?.focus();
     }
-    onopen?.({ event })
+    onopen?.({ event });
   }
 
   function close_dropdown(event: Event, retain_focus = false) {
-    open = false
-    if (!retain_focus) input?.blur()
-    activeIndex = null
-    onclose?.({ event })
+    open = false;
+    if (!retain_focus) input?.blur();
+    activeIndex = null;
+    onclose?.({ event });
   }
 
   function clear_validity() {
-    invalid = false
-    form_input?.setCustomValidity(``)
+    invalid = false;
+    form_input?.setCustomValidity(``);
   }
 
   function handle_dropdown_after_select(event: Event) {
-    const reached_max = selected.length >= (maxSelect ?? Infinity)
-    const should_close = closeDropdownOnSelect === true ||
+    const reached_max = selected.length >= (maxSelect ?? Infinity);
+    const should_close =
+      closeDropdownOnSelect === true ||
       closeDropdownOnSelect === `retain-focus` ||
-      (closeDropdownOnSelect === `if-mobile` && window_width &&
-        window_width < breakpoint)
+      (closeDropdownOnSelect === `if-mobile` &&
+        window_width &&
+        window_width < breakpoint);
     if (reached_max || should_close) {
-      close_dropdown(event, closeDropdownOnSelect === `retain-focus`)
-    } else input?.focus()
+      close_dropdown(event, closeDropdownOnSelect === `retain-focus`);
+    } else input?.focus();
   }
 
   // Check if a user message (create option, duplicate warning, no match) is visible
   const has_user_msg = $derived(
-    searchText.length > 0 && Boolean(
-      (allowUserOptions && createOptionMsg) ||
-        (!duplicates && selected_labels_set.has(searchText)) ||
-        (navigable_options.length === 0 && noMatchingOptionsMsg),
-    ),
-  )
+    searchText.length > 0 &&
+      Boolean(
+        (allowUserOptions && createOptionMsg) ||
+          (!duplicates && selected_labels_set.has(searchText)) ||
+          (navigable_options.length === 0 && noMatchingOptionsMsg),
+      ),
+  );
 
   // Handle arrow key navigation through options (uses navigable_options to skip collapsed groups)
   async function handle_arrow_navigation(direction: 1 | -1) {
-    ignore_hover = true
+    ignore_hover = true;
 
     // Auto-expand collapsed groups when keyboard navigating
     if (
-      keyboardExpandsCollapsedGroups && collapsibleGroups && collapsedGroups.size > 0
+      keyboardExpandsCollapsedGroups &&
+      collapsibleGroups &&
+      collapsedGroups.size > 0
     ) {
-      expand_groups(get_collapsed_with_matches())
-      await tick()
+      expand_groups(get_collapsed_with_matches());
+      await tick();
     }
 
     // toggle user message when no options match but user can create
-    if (allowUserOptions && !navigable_options.length && searchText.length > 0) {
-      option_msg_is_active = !option_msg_is_active
-      return
+    if (
+      allowUserOptions &&
+      !navigable_options.length &&
+      searchText.length > 0
+    ) {
+      option_msg_is_active = !option_msg_is_active;
+      return;
     }
-    if (activeIndex === null && !navigable_options.length) return // nothing to navigate
+    if (activeIndex === null && !navigable_options.length) return; // nothing to navigate
 
     // activate first option or navigate with wrap-around
     if (activeIndex === null) {
-      activeIndex = 0
+      activeIndex = 0;
     } else {
-      const total = navigable_options.length + (has_user_msg ? 1 : 0)
+      const total = navigable_options.length + (has_user_msg ? 1 : 0);
       // Guard against division by zero (can happen if options filtered away before effect resets activeIndex)
       if (total === 0) {
-        activeIndex = null
-        return
+        activeIndex = null;
+        return;
       }
-      activeIndex = (activeIndex + direction + total) % total // +total handles negative mod
+      activeIndex = (activeIndex + direction + total) % total; // +total handles negative mod
     }
 
     // update active state based on new index
-    option_msg_is_active = has_user_msg && activeIndex === navigable_options.length
+    option_msg_is_active =
+      has_user_msg && activeIndex === navigable_options.length;
     activeOption = option_msg_is_active
       ? null
-      : navigable_options[activeIndex] ?? null
+      : (navigable_options[activeIndex] ?? null);
 
     if (autoScroll) {
-      await tick()
-      document.querySelector(`ul.options > li.active`)?.scrollIntoViewIfNeeded?.()
+      await tick();
+      document
+        .querySelector(`ul.options > li.active`)
+        ?.scrollIntoViewIfNeeded?.();
     }
 
     // Fire onactivate for keyboard navigation only (not mouse hover)
-    onactivate?.({ option: activeOption, index: activeIndex })
+    onactivate?.({ option: activeOption, index: activeIndex });
   }
 
   // handle all keyboard events this component receives
   async function handle_keydown(event: KeyboardEvent) {
-    if (disabled) return // Block all keyboard handling when disabled
+    if (disabled) return; // Block all keyboard handling when disabled
 
     // Check keyboard shortcuts first (before other key handling)
     const shortcut_actions: Array<{
-      key: keyof typeof effective_shortcuts
-      condition: () => boolean
-      action: () => void
+      key: keyof typeof effective_shortcuts;
+      condition: () => boolean;
+      action: () => void;
     }> = [
       {
         key: `select_all`,
@@ -814,121 +881,124 @@
         key: `close`,
         condition: () => open,
         action: () => {
-          close_dropdown(event)
-          searchText = ``
+          close_dropdown(event);
+          searchText = ``;
         },
       },
-    ]
+    ];
 
     for (const { key, condition, action } of shortcut_actions) {
       if (matches_shortcut(event, effective_shortcuts[key]) && condition()) {
-        event.preventDefault()
-        event.stopPropagation()
-        action()
-        return
+        event.preventDefault();
+        event.stopPropagation();
+        action();
+        return;
       }
     }
 
     // on escape or tab out of input: close options dropdown and reset search text
     if (event.key === `Escape` || event.key === `Tab`) {
-      event.stopPropagation()
-      close_dropdown(event)
-      searchText = ``
+      event.stopPropagation();
+      close_dropdown(event);
+      searchText = ``;
     } // on enter key: toggle active option
     else if (event.key === `Enter`) {
-      event.stopPropagation()
-      event.preventDefault() // prevent enter key from triggering form submission
+      event.stopPropagation();
+      event.preventDefault(); // prevent enter key from triggering form submission
 
       if (activeOption) {
         if (selected_keys_set.has(key(activeOption))) {
-          if (can_remove) remove(activeOption, event)
-        } else add(activeOption, event) // add() handles resetFilterOnAdd internally when successful
+          if (can_remove) remove(activeOption, event);
+        } else add(activeOption, event); // add() handles resetFilterOnAdd internally when successful
       } else if (allowUserOptions && searchText.length > 0) {
         // user entered text but no options match, so if allowUserOptions is truthy, we create new option
-        add(searchText as Option, event)
+        add(searchText as Option, event);
       } else {
         // no active option and no search text means the options dropdown is closed
         // in which case enter means open it
-        open_dropdown(event)
+        open_dropdown(event);
       }
     } // on up/down arrow keys: update active option
     else if (event.key === `ArrowDown` || event.key === `ArrowUp`) {
-      event.stopPropagation()
-      event.preventDefault()
-      await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1)
+      event.stopPropagation();
+      event.preventDefault();
+      await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1);
     } // on backspace key: remove last selected option
     else if (event.key === `Backspace` && selected.length > 0 && !searchText) {
-      event.stopPropagation()
+      event.stopPropagation();
       if (can_remove) {
-        const last_option = selected.at(-1)
-        if (last_option) remove(last_option, event)
+        const last_option = selected.at(-1);
+        if (last_option) remove(last_option, event);
       }
       // Don't prevent default, allow normal backspace behavior if not removing
     } // make first matching option active on any keypress (if none of the above special cases match)
     else if (navigable_options.length > 0 && activeIndex === null) {
       // Don't stop propagation or prevent default here, allow normal character input
-      activeIndex = 0
+      activeIndex = 0;
     }
   }
 
   function remove_all(event: Event) {
-    event.stopPropagation()
+    event.stopPropagation();
 
     // Keep the first minSelect items, remove the rest
-    let removed_options: Option[] = []
+    let removed_options: Option[] = [];
     if (minSelect === null) {
       // If no minSelect constraint, remove all
-      removed_options = selected
-      selected = []
+      removed_options = selected;
+      selected = [];
     } else if (selected.length > minSelect) {
       // Keep the first minSelect items
-      removed_options = selected.slice(minSelect)
-      selected = selected.slice(0, minSelect)
+      removed_options = selected.slice(minSelect);
+      selected = selected.slice(0, minSelect);
     }
     // Only fire events if something was actually removed
     if (removed_options.length > 0) {
-      searchText = `` // always clear on remove all (resetFilterOnAdd only applies to add operations)
-      last_action = { type: `removeAll`, label: `${removed_options.length} options` }
-      onremoveAll?.({ options: removed_options })
-      onchange?.({ options: selected, type: `removeAll` })
+      searchText = ``; // always clear on remove all (resetFilterOnAdd only applies to add operations)
+      last_action = {
+        type: `removeAll`,
+        label: `${removed_options.length} options`,
+      };
+      onremoveAll?.({ options: removed_options });
+      onchange?.({ options: selected, type: `removeAll` });
     }
   }
 
   // Check if option index is within maxOptions visibility limit
   const is_option_visible = (idx: number) =>
-    idx >= 0 && (maxOptions == null || idx < maxOptions)
+    idx >= 0 && (maxOptions == null || idx < maxOptions);
 
   // Get non-disabled, selectable options from a list
   // For collapsed groups: returns all non-disabled options (user explicitly wants this group)
   // For expanded groups/top-level: respects maxOptions rendering limit
   const get_selectable_opts = (opts: Option[], skip_visibility_check = false) =>
     opts.filter((opt) => {
-      if (is_disabled(opt)) return false
-      if (skip_visibility_check) return true
-      return is_option_visible(navigable_index_map.get(opt) ?? -1)
-    })
+      if (is_disabled(opt)) return false;
+      if (skip_visibility_check) return true;
+      return is_option_visible(navigable_index_map.get(opt) ?? -1);
+    });
 
   // Batch-add options to selection with all side effects (used by select_all and group select)
   function batch_add_options(options_to_add: Option[], event: Event) {
-    const remaining = Math.max(0, (maxSelect ?? Infinity) - selected.length)
+    const remaining = Math.max(0, (maxSelect ?? Infinity) - selected.length);
     const to_add = options_to_add
       .filter((opt) => !selected_keys_set.has(key(opt)))
-      .slice(0, remaining)
+      .slice(0, remaining);
 
-    if (to_add.length === 0) return
+    if (to_add.length === 0) return;
 
-    selected = sort_selected([...selected, ...to_add])
-    if (resetFilterOnAdd) searchText = ``
-    clear_validity()
-    handle_dropdown_after_select(event)
-    onselectAll?.({ options: to_add })
-    onchange?.({ options: selected, type: `selectAll` })
+    selected = sort_selected([...selected, ...to_add]);
+    if (resetFilterOnAdd) searchText = ``;
+    clear_validity();
+    handle_dropdown_after_select(event);
+    onselectAll?.({ options: to_add });
+    onchange?.({ options: selected, type: `selectAll` });
   }
 
   // Batch-add options for top-level "Select all" (only visible/navigable options)
   function select_all(event: Event) {
-    event.stopPropagation()
-    batch_add_options(get_selectable_opts(navigable_options), event)
+    event.stopPropagation();
+    batch_add_options(get_selectable_opts(navigable_options), event);
   }
 
   // Toggle group selection: works even when group is collapsed
@@ -939,33 +1009,34 @@
     all_selected: boolean,
     event: Event,
   ) {
-    event.stopPropagation()
-    const selectable = get_selectable_opts(group_opts, group_collapsed)
+    event.stopPropagation();
+    const selectable = get_selectable_opts(group_opts, group_collapsed);
     if (all_selected) {
       // Deselect all options in this group
-      const keys_to_remove = new Set(selectable.map(key))
-      const removed = selected.filter((opt) => keys_to_remove.has(key(opt)))
-      selected = selected.filter((opt) => !keys_to_remove.has(key(opt)))
+      const keys_to_remove = new Set(selectable.map(key));
+      const removed = selected.filter((opt) => keys_to_remove.has(key(opt)));
+      selected = selected.filter((opt) => !keys_to_remove.has(key(opt)));
       if (removed.length > 0) {
-        onremoveAll?.({ options: removed })
-        onchange?.({ options: selected, type: `removeAll` })
+        onremoveAll?.({ options: removed });
+        onchange?.({ options: selected, type: `removeAll` });
       }
     } else {
       // Select all non-disabled, non-selected options in this group
-      batch_add_options(selectable, event)
+      batch_add_options(selectable, event);
     }
   }
 
   // O(1) lookup using pre-computed Set instead of O(n) array.includes()
-  const is_selected = (label: string | number) => selected_labels_set.has(label)
+  const is_selected = (label: string | number) =>
+    selected_labels_set.has(label);
 
   const if_enter_or_space =
     (handler: (event: KeyboardEvent) => void) => (event: KeyboardEvent) => {
       if (event.key === `Enter` || event.code === `Space`) {
-        event.preventDefault()
-        handler(event)
+        event.preventDefault();
+        handler(event);
       }
-    }
+    };
 
   // Handle option interaction (click or keyboard) - DRY helper for template
   const handle_option_interact = (
@@ -973,225 +1044,235 @@
     opt_disabled: boolean | null,
     event: Event,
   ) => {
-    if (opt_disabled) return
-    if (keepSelectedInDropdown) toggle_option(opt, event)
-    else add(opt, event)
-  }
+    if (opt_disabled) return;
+    if (keepSelectedInDropdown) toggle_option(opt, event);
+    else add(opt, event);
+  };
 
   function on_click_outside(event: MouseEvent | TouchEvent) {
-    if (!outerDiv) return
-    const target = event.target as Node
+    if (!outerDiv) return;
+    const target = event.target as Node;
     // Check if click is inside the main component
-    if (outerDiv.contains(target)) return
+    if (outerDiv.contains(target)) return;
     // If portal is active, also check if click is inside the portalled options dropdown
-    if (portal_params?.active && ul_options && ul_options.contains(target)) return
+    if (portal_params?.active && ul_options && ul_options.contains(target))
+      return;
     // Click is outside both the main component and any portalled dropdown
-    close_dropdown(event)
+    close_dropdown(event);
   }
 
-  let drag_idx: number | null = $state(null)
+  let drag_idx: number | null = $state(null);
   // event handlers enable dragging to reorder selected options
   const drop = (target_idx: number) => (event: DragEvent) => {
-    if (!event.dataTransfer) return
-    event.dataTransfer.dropEffect = `move`
-    const start_idx = parseInt(event.dataTransfer.getData(`text/plain`))
-    const new_selected = [...selected]
+    if (!event.dataTransfer) return;
+    event.dataTransfer.dropEffect = `move`;
+    const start_idx = parseInt(event.dataTransfer.getData(`text/plain`));
+    const new_selected = [...selected];
 
     if (start_idx < target_idx) {
-      new_selected.splice(target_idx + 1, 0, new_selected[start_idx])
-      new_selected.splice(start_idx, 1)
+      new_selected.splice(target_idx + 1, 0, new_selected[start_idx]);
+      new_selected.splice(start_idx, 1);
     } else {
-      new_selected.splice(target_idx, 0, new_selected[start_idx])
-      new_selected.splice(start_idx + 1, 1)
+      new_selected.splice(target_idx, 0, new_selected[start_idx]);
+      new_selected.splice(start_idx + 1, 1);
     }
-    selected = new_selected
-    drag_idx = null
-    onreorder?.({ options: new_selected })
-    onchange?.({ options: new_selected, type: `reorder` })
-  }
+    selected = new_selected;
+    drag_idx = null;
+    onreorder?.({ options: new_selected });
+    onchange?.({ options: new_selected, type: `reorder` });
+  };
 
   const dragstart = (idx: number) => (event: DragEvent) => {
-    if (!event.dataTransfer) return
+    if (!event.dataTransfer) return;
     // only allow moving, not copying (also affects the cursor during drag)
-    event.dataTransfer.effectAllowed = `move`
-    event.dataTransfer.dropEffect = `move`
-    event.dataTransfer.setData(`text/plain`, `${idx}`)
-  }
+    event.dataTransfer.effectAllowed = `move`;
+    event.dataTransfer.dropEffect = `move`;
+    event.dataTransfer.setData(`text/plain`, `${idx}`);
+  };
 
-  let ul_options = $state<HTMLUListElement>()
+  let ul_options = $state<HTMLUListElement>();
 
-  const handle_input_keydown: KeyboardEventHandler<HTMLInputElement> = (event) => {
-    handle_keydown(event) // Restore internal logic
+  const handle_input_keydown: KeyboardEventHandler<HTMLInputElement> = (
+    event,
+  ) => {
+    handle_keydown(event); // Restore internal logic
     // Call original forwarded handler
-    onkeydown?.(event)
-  }
+    onkeydown?.(event);
+  };
 
   const handle_input_focus: FocusEventHandler<HTMLInputElement> = (event) => {
-    open_dropdown(event)
-    onfocus?.(event)
-  }
+    open_dropdown(event);
+    onfocus?.(event);
+  };
 
   // Override input's focus method to ensure dropdown opens on programmatic focus
   // https://github.com/janosh/svelte-multiselect/issues/289
   $effect(() => {
-    if (!input) return
+    if (!input) return;
 
-    const orig_focus = input.focus.bind(input)
+    const orig_focus = input.focus.bind(input);
 
     input.focus = (options?: FocusOptions) => {
-      orig_focus(options)
+      orig_focus(options);
       if (!disabled && !open) {
-        open_dropdown(new FocusEvent(`focus`, { bubbles: true }))
+        open_dropdown(new FocusEvent(`focus`, { bubbles: true }));
       }
-    }
+    };
 
     return () => {
-      if (input) input.focus = orig_focus
-    }
-  })
+      if (input) input.focus = orig_focus;
+    };
+  });
 
   const handle_input_blur: FocusEventHandler<HTMLInputElement> = (event) => {
     // For portalled dropdowns, don't close on blur since clicks on portalled elements
     // will cause blur but we want to allow the click to register first
     // (otherwise mobile touch event is unable to select options https://github.com/janosh/svelte-multiselect/issues/335)
     if (portal_params?.active) {
-      onblur?.(event) // Let the click handler manage closing for portalled dropdowns
-      return
+      onblur?.(event); // Let the click handler manage closing for portalled dropdowns
+      return;
     }
 
     // For non-portalled dropdowns, close when focus moves outside the component
-    if (!outerDiv?.contains(event.relatedTarget as Node)) close_dropdown(event)
+    if (!outerDiv?.contains(event.relatedTarget as Node)) close_dropdown(event);
 
-    onblur?.(event) // Call original handler (if any passed as component prop)
-  }
+    onblur?.(event); // Call original handler (if any passed as component prop)
+  };
 
   // reset form validation when required prop changes
   // https://github.com/janosh/svelte-multiselect/issues/285
   $effect.pre(() => {
-    required = required // trigger effect when required changes
-    form_input?.setCustomValidity(``)
-  })
+    required = required; // trigger effect when required changes
+    form_input?.setCustomValidity(``);
+  });
 
-  type PortalParams = { target_node: HTMLElement | null; active?: boolean }
+  type PortalParams = { target_node: HTMLElement | null; active?: boolean };
   function portal(node: HTMLElement, params: PortalParams) {
-    let { target_node, active } = params
-    if (!active) return
-    let render_in_place = typeof window === `undefined` ||
-      !document.body.contains(node)
+    let { target_node, active } = params;
+    if (!active) return;
+    let render_in_place =
+      typeof window === `undefined` || !document.body.contains(node);
 
     if (!render_in_place) {
-      document.body.appendChild(node)
-      node.style.position = `fixed`
+      document.body.appendChild(node);
+      node.style.position = `fixed`;
 
       const update_position = () => {
-        if (!target_node || !open) return (node.hidden = true)
-        const rect = target_node.getBoundingClientRect()
-        node.style.left = `${rect.left}px`
-        node.style.top = `${rect.bottom}px`
-        node.style.width = `${rect.width}px`
-        node.hidden = false
-      }
+        if (!target_node || !open) return (node.hidden = true);
+        const rect = target_node.getBoundingClientRect();
+        node.style.left = `${rect.left}px`;
+        node.style.top = `${rect.bottom}px`;
+        node.style.width = `${rect.width}px`;
+        node.hidden = false;
+      };
 
-      if (open) tick().then(update_position)
+      if (open) tick().then(update_position);
 
-      window.addEventListener(`scroll`, update_position, true)
-      window.addEventListener(`resize`, update_position)
+      window.addEventListener(`scroll`, update_position, true);
+      window.addEventListener(`resize`, update_position);
 
       $effect(() => {
-        if (open && target_node) update_position()
-        else node.hidden = true
-      })
+        if (open && target_node) update_position();
+        else node.hidden = true;
+      });
 
       return {
         update(params: PortalParams) {
-          target_node = params.target_node
-          render_in_place = typeof window === `undefined` ||
-            !document.body.contains(node)
-          if (open && !render_in_place && target_node) tick().then(update_position)
-          else if (!open || !target_node) node.hidden = true
+          target_node = params.target_node;
+          render_in_place =
+            typeof window === `undefined` || !document.body.contains(node);
+          if (open && !render_in_place && target_node)
+            tick().then(update_position);
+          else if (!open || !target_node) node.hidden = true;
         },
         destroy() {
-          if (!render_in_place) node.remove()
-          window.removeEventListener(`scroll`, update_position, true)
-          window.removeEventListener(`resize`, update_position)
+          if (!render_in_place) node.remove();
+          window.removeEventListener(`scroll`, update_position, true);
+          window.removeEventListener(`resize`, update_position);
         },
-      }
+      };
     }
   }
 
   // Dynamic options loading - captures search at call time to avoid race conditions
   async function load_dynamic_options(reset: boolean) {
     if (
-      !load_options_config || load_options_loading ||
+      !load_options_config ||
+      load_options_loading ||
       (!reset && !load_options_has_more)
     ) {
-      return
+      return;
     }
     // Capture search term at call time to avoid race with user typing during fetch
-    const search = searchText
-    const offset = reset ? 0 : loaded_options.length
-    load_options_loading = true
+    const search = searchText;
+    const offset = reset ? 0 : loaded_options.length;
+    load_options_loading = true;
     try {
-      const limit = load_options_config.batch_size
-      const result = await load_options_config.fetch({ search, offset, limit })
-      loaded_options = reset ? result.options : [...loaded_options, ...result.options]
-      load_options_has_more = result.hasMore
-      load_options_last_search = search
+      const limit = load_options_config.batch_size;
+      const result = await load_options_config.fetch({ search, offset, limit });
+      loaded_options = reset
+        ? result.options
+        : [...loaded_options, ...result.options];
+      load_options_has_more = result.hasMore;
+      load_options_last_search = search;
     } catch (err) {
-      console.error(`MultiSelect: loadOptions error:`, err)
+      console.error(`MultiSelect: loadOptions error:`, err);
     } finally {
-      load_options_loading = false
+      load_options_loading = false;
     }
   }
 
   // Single effect handles initial load + search changes
   $effect(() => {
-    if (!load_options_config) return
+    if (!load_options_config) return;
 
     // Reset state when dropdown closes so next open triggers fresh load
     if (!open) {
-      load_options_last_search = null
-      loaded_options = []
-      load_options_has_more = true
-      return
+      load_options_last_search = null;
+      loaded_options = [];
+      load_options_has_more = true;
+      return;
     }
 
-    if (debounce_timer) clearTimeout(debounce_timer)
+    if (debounce_timer) clearTimeout(debounce_timer);
 
-    const search = searchText
-    const is_first_load = load_options_last_search === null
+    const search = searchText;
+    const is_first_load = load_options_last_search === null;
 
     if (is_first_load) {
       if (load_options_config.on_open) {
         // Load immediately on dropdown open
-        load_dynamic_options(true)
+        load_dynamic_options(true);
       } else if (search) {
         // onOpen=false but user typed - debounce and load
         debounce_timer = setTimeout(
           () => load_dynamic_options(true),
           load_options_config.debounce_ms,
-        )
+        );
       }
       // If onOpen=false and no search text, do nothing (wait for user to type)
     } else if (search !== load_options_last_search) {
       // Subsequent loads: debounce search changes
       // Clear stale results immediately so UI doesn't show wrong results while loading
-      loaded_options = []
-      load_options_has_more = true
+      loaded_options = [];
+      load_options_has_more = true;
       debounce_timer = setTimeout(
         () => load_dynamic_options(true),
         load_options_config.debounce_ms,
-      )
+      );
     }
     return () => {
-      if (debounce_timer) clearTimeout(debounce_timer)
-    }
-  })
+      if (debounce_timer) clearTimeout(debounce_timer);
+    };
+  });
 
   function handle_options_scroll(event: Event) {
-    if (!load_options_config || load_options_loading || !load_options_has_more) return
-    const { scrollTop, scrollHeight, clientHeight } = event.target as HTMLElement
-    if (scrollHeight - scrollTop - clientHeight <= 100) load_dynamic_options(false)
+    if (!load_options_config || load_options_loading || !load_options_has_more)
+      return;
+    const { scrollTop, scrollHeight, clientHeight } =
+      event.target as HTMLElement;
+    if (scrollHeight - scrollTop - clientHeight <= 100)
+      load_dynamic_options(false);
   }
 </script>
 
@@ -1220,23 +1301,25 @@
   <input
     {name}
     required={Boolean(required)}
-    value={selected.length >= Number(required) ? JSON.stringify(selected) : null}
+    value={selected.length >= Number(required)
+      ? JSON.stringify(selected)
+      : null}
     tabindex="-1"
     aria-hidden="true"
     aria-label="ignore this, used only to prevent form submission if select is required but empty"
     class="form-control"
     bind:this={form_input}
     oninvalid={() => {
-      invalid = true
-      let msg
+      invalid = true;
+      let msg;
       if (maxSelect && maxSelect > 1 && Number(required) > 1) {
-        msg = `Please select between ${required} and ${maxSelect} options`
+        msg = `Please select between ${required} and ${maxSelect} options`;
       } else if (Number(required) > 1) {
-        msg = `Please select at least ${required} options`
+        msg = `Please select at least ${required} options`;
       } else {
-        msg = `Please select an option`
+        msg = `Please select an option`;
       }
-      form_input?.setCustomValidity(msg)
+      form_input?.setCustomValidity(msg);
     }}
   />
   <span class="expand-icon">
@@ -1256,10 +1339,9 @@
   >
     {#each selected as option, idx (duplicates ? `${key(option)}-${idx}` : key(option))}
       {@const selectedOptionStyle =
-        [get_style(option, `selected`), liSelectedStyle].filter(Boolean).join(
-          ` `,
-        ) ||
-        null}
+        [get_style(option, `selected`), liSelectedStyle]
+          .filter(Boolean)
+          .join(` `) || null}
       <li
         class={liSelectedClass}
         role="option"
@@ -1268,7 +1350,7 @@
         draggable={selectedOptionsDraggable && !disabled && selected.length > 1}
         ondragstart={dragstart(idx)}
         ondragover={(event) => {
-          event.preventDefault() // needed for ondrop to fire
+          event.preventDefault(); // needed for ondrop to fire
         }}
         ondrop={drop(idx)}
         ondragenter={() => (drag_idx = idx)}
@@ -1278,14 +1360,14 @@
       >
         {#if selectedItem}
           {@render selectedItem({
-          option,
-          idx,
-        })}
+            option,
+            idx,
+          })}
         {:else if children}
           {@render children({
-          option,
-          idx,
-        })}
+            option,
+            idx,
+          })}
         {:else if parseLabelsAsHtml}
           {@html get_label(option)}
         {:else}
@@ -1318,7 +1400,9 @@
       {autocomplete}
       {inputmode}
       {pattern}
-      placeholder={selected.length === 0 || placeholder_persistent ? placeholder_text : null}
+      placeholder={selected.length === 0 || placeholder_persistent
+        ? placeholder_text
+        : null}
       role="combobox"
       aria-haspopup="listbox"
       aria-expanded={open}
@@ -1343,14 +1427,14 @@
       {...rest}
     />
     {@render afterInput?.({
-        selected,
-        disabled,
-        invalid,
-        id,
-        placeholder: placeholder_text,
-        open,
-        required,
-      })}
+      selected,
+      disabled,
+      invalid,
+      id,
+      placeholder: placeholder_text,
+      open,
+      required,
+    })}
   </ul>
   {#if loading}
     {#if spinner}
@@ -1396,8 +1480,7 @@
   {/if}
 
   <!-- only render options dropdown if options or searchText is not empty (needed to avoid briefly flashing empty dropdown) -->
-  {#if (searchText && noMatchingOptionsMsg) || effective_options.length > 0 ||
-      loadOptions}
+  {#if (searchText && noMatchingOptionsMsg) || effective_options.length > 0 || loadOptions}
     <ul
       use:portal={{ target_node: outerDiv, ...portal_params }}
       {@attach highlight_matches({
@@ -1423,9 +1506,9 @@
       onscroll={handle_options_scroll}
       onmousemove={() => (ignore_hover = false)}
     >
-      {#if selectAllOption && effective_options.length > 0 &&
-        (maxSelect === null || maxSelect > 1)}
-        {@const label = typeof selectAllOption === `string` ? selectAllOption : `Select all`}
+      {#if selectAllOption && effective_options.length > 0 && (maxSelect === null || maxSelect > 1)}
+        {@const label =
+          typeof selectAllOption === `string` ? selectAllOption : `Select all`}
         <li
           class="select-all {liSelectAllClass}"
           onclick={select_all}
@@ -1437,18 +1520,15 @@
           {label}
         </li>
       {/if}
-      {#each grouped_options as
-        { group: group_name, options: group_opts, collapsed },
-        group_idx
-        (group_name ?? `ungrouped-${group_idx}`)
-      }
+      {#each grouped_options as { group: group_name, options: group_opts, collapsed }, group_idx (group_name ?? `ungrouped-${group_idx}`)}
         {#if group_name !== null}
-          {@const { all_selected, selected_count } = group_header_state.get(group_name) ??
-        { all_selected: false, selected_count: 0 }}
+          {@const { all_selected, selected_count } = group_header_state.get(
+            group_name,
+          ) ?? { all_selected: false, selected_count: 0 }}
           {@const handle_toggle = () =>
-        collapsibleGroups && toggle_group_collapsed(group_name)}
+            collapsibleGroups && toggle_group_collapsed(group_name)}
           {@const handle_group_select = (event: Event) =>
-        toggle_group_selection(group_opts, collapsed, all_selected, event)}
+            toggle_group_selection(group_opts, collapsed, all_selected, event)}
           <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
           <li
             class="group-header {liGroupHeaderClass}"
@@ -1463,7 +1543,11 @@
             tabindex={collapsibleGroups ? 0 : -1}
           >
             {#if groupHeader}
-              {@render groupHeader({ group: group_name, options: group_opts, collapsed })}
+              {@render groupHeader({
+                group: group_name,
+                options: group_opts,
+                collapsed,
+              })}
             {:else}
               <span class="group-label">{group_name}</span>
               <span class="group-count">
@@ -1494,42 +1578,38 @@
           </li>
         {/if}
         {#if !collapsed || !collapsibleGroups}
-          {#each group_opts as
-            option_item,
-            local_idx
-            (duplicates
-        ? `${key(option_item)}-${group_idx}-${local_idx}`
-        : key(option_item))
-          }
+          {#each group_opts as option_item, local_idx (duplicates ? `${key(option_item)}-${group_idx}-${local_idx}` : key(option_item))}
             {@const flat_idx = navigable_index_map.get(option_item) ?? -1}
             {@const {
-        label,
-        disabled = null,
-        title = null,
-        selectedTitle = null,
-        disabledTitle = defaultDisabledTitle,
-      } = is_object(option_item) ? option_item : { label: option_item }}
+              label,
+              disabled = null,
+              title = null,
+              selectedTitle = null,
+              disabledTitle = defaultDisabledTitle,
+            } = is_object(option_item) ? option_item : { label: option_item }}
             {@const active = activeIndex === flat_idx && flat_idx >= 0}
             {@const selected = is_selected(label)}
             {@const optionStyle =
-        [get_style(option_item, `option`), liOptionStyle].filter(Boolean).join(
-          ` `,
-        ) ||
-        null}
+              [get_style(option_item, `option`), liOptionStyle]
+                .filter(Boolean)
+                .join(` `) || null}
             {#if is_option_visible(flat_idx)}
               <li
                 id="{internal_id}-opt-{flat_idx}"
-                onclick={(event) => handle_option_interact(option_item, disabled, event)}
-                title={disabled ? disabledTitle : (selected && selectedTitle) || title}
+                onclick={(event) =>
+                  handle_option_interact(option_item, disabled, event)}
+                title={disabled
+                  ? disabledTitle
+                  : (selected && selectedTitle) || title}
                 class:selected
                 class:active
                 class:disabled
                 class="{liOptionClass} {active ? liActiveOptionClass : ``}"
                 onmouseover={() => {
-                  if (!disabled && !ignore_hover) activeIndex = flat_idx
+                  if (!disabled && !ignore_hover) activeIndex = flat_idx;
                 }}
                 onfocus={() => {
-                  if (!disabled) activeIndex = flat_idx
+                  if (!disabled) activeIndex = flat_idx;
                 }}
                 role="option"
                 aria-selected={selected ? `true` : `false`}
@@ -1537,7 +1617,7 @@
                 aria-setsize={navigable_options.length}
                 style={optionStyle}
                 onkeydown={if_enter_or_space((event) =>
-                  handle_option_interact(option_item, disabled, event)
+                  handle_option_interact(option_item, disabled, event),
                 )}
               >
                 {#if keepSelectedInDropdown === `checkboxes`}
@@ -1551,14 +1631,14 @@
                 {/if}
                 {#if option}
                   {@render option({
-          option: option_item,
-          idx: flat_idx,
-        })}
+                    option: option_item,
+                    idx: flat_idx,
+                  })}
                 {:else if children}
                   {@render children({
-          option: option_item,
-          idx: flat_idx,
-        })}
+                    option: option_item,
+                    idx: flat_idx,
+                  })}
                 {:else if parseLabelsAsHtml}
                   {@html get_label(option_item)}
                 {:else}
@@ -1572,28 +1652,33 @@
       {#if searchText}
         {@const text_input_is_duplicate = selected_labels.includes(searchText)}
         {@const is_dupe = !duplicates && text_input_is_duplicate && `dupe`}
-        {@const can_create = Boolean(allowUserOptions && createOptionMsg) && `create`}
+        {@const can_create =
+          Boolean(allowUserOptions && createOptionMsg) && `create`}
         {@const no_match =
-        Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg) &&
-        `no-match`}
+          Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg) &&
+          `no-match`}
         {@const msgType = is_dupe || can_create || no_match}
-        {@const msg = msgType && {
-        dupe: duplicateOptionMsg,
-        create: createOptionMsg,
-        'no-match': noMatchingOptionsMsg,
-      }[msgType]}
+        {@const msg =
+          msgType &&
+          {
+            dupe: duplicateOptionMsg,
+            create: createOptionMsg,
+            "no-match": noMatchingOptionsMsg,
+          }[msgType]}
         {@const can_add_user_option = msgType === `create` && allowUserOptions}
         {@const handle_create = (event: Event) =>
-        can_add_user_option && add(searchText as Option, event)}
+          can_add_user_option && add(searchText as Option, event)}
         {#if msg}
           <li
             onclick={handle_create}
-            onkeydown={can_add_user_option ? if_enter_or_space(handle_create) : undefined}
+            onkeydown={can_add_user_option
+              ? if_enter_or_space(handle_create)
+              : undefined}
             title={msgType === `create`
-            ? createOptionMsg
-            : msgType === `dupe`
-            ? duplicateOptionMsg
-            : ``}
+              ? createOptionMsg
+              : msgType === `dupe`
+                ? duplicateOptionMsg
+                : ``}
             class:active={option_msg_is_active}
             onmouseover={() => !ignore_hover && (option_msg_is_active = true)}
             onfocus={() => (option_msg_is_active = true)}
@@ -1609,7 +1694,7 @@
             style:cursor={{
               dupe: `not-allowed`,
               create: `pointer`,
-              'no-match': `default`,
+              "no-match": `default`,
             }[msgType]}
           >
             {#if userMsg}
@@ -1621,7 +1706,11 @@
         {/if}
       {/if}
       {#if loadOptions && load_options_loading}
-        <li class="loading-more" role="status" aria-label="Loading more options">
+        <li
+          class="loading-more"
+          role="status"
+          aria-label="Loading more options"
+        >
           <CircleSpinner />
         </li>
       {/if}
@@ -1682,7 +1771,10 @@
     z-index: var(--sms-open-z-index, 4);
   }
   :where(div.multiselect:focus-within) {
-    border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));
+    border: var(
+      --sms-focus-border,
+      1pt solid var(--sms-active-color, cornflowerblue)
+    );
   }
   :where(div.multiselect.disabled) {
     background: var(--sms-disabled-bg, light-dark(lightgray, #444));
@@ -1711,13 +1803,16 @@
     padding: var(--sms-selected-li-padding, 1pt 5pt);
     color: var(--sms-selected-text-color, var(--sms-text-color));
   }
-  :where(div.multiselect > ul.selected > li[draggable='true']) {
+  :where(div.multiselect > ul.selected > li[draggable="true"]) {
     cursor: grab;
   }
   :where(div.multiselect > ul.selected > li.active) {
     background: var(
       --sms-li-active-bg,
-      var(--sms-active-color, light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)))
+      var(
+        --sms-active-color,
+        light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15))
+      )
     );
   }
   :is(div.multiselect button) {
@@ -1796,8 +1891,7 @@
     z-index: var(--sms-options-z-index, 3);
 
     overflow: auto;
-    transition: all
-      0.2s; /* Consider if this transition is desirable with portal positioning */
+    transition: all 0.2s; /* Consider if this transition is desirable with portal positioning */
     box-sizing: border-box;
     background: var(--sms-options-bg, light-dark(#fafafa, #1a1a1a));
     max-height: var(--sms-options-max-height, 50vh);
@@ -1842,7 +1936,10 @@
   :where(ul.options > li.active) {
     background: var(
       --sms-li-active-bg,
-      var(--sms-active-color, light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15)))
+      var(
+        --sms-active-color,
+        light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.15))
+      )
     );
   }
   :where(ul.options > li.disabled) {
@@ -1896,7 +1993,10 @@
   }
   :where(ul.options > li.group-header:not(:first-child)) {
     margin-top: var(--sms-group-header-margin-top, 4pt);
-    border-top: var(--sms-group-header-border-top, 1px solid light-dark(#eee, #333));
+    border-top: var(
+      --sms-group-header-border-top,
+      1px solid light-dark(#eee, #333)
+    );
   }
   :where(ul.options > li.group-header.collapsible) {
     cursor: pointer;
@@ -1929,8 +2029,11 @@
   }
   /* Indent grouped options for visual hierarchy */
   :where(
-    ul.options > li:not(.group-header):not(.select-all):not(.user-msg):not(.loading-more)
-  ) {
+      ul.options
+        > li:not(.group-header):not(.select-all):not(.user-msg):not(
+          .loading-more
+        )
+    ) {
     padding-left: var(
       --sms-group-item-padding-left,
       var(--sms-group-option-indent, 1.5ex)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -1,28 +1,15 @@
 <!-- eslint-disable-next-line @stylistic/quotes -- TS generics require string literals -->
 <script lang="ts" generics="Option extends import('./types').Option">
-  import { tick, untrack } from "svelte";
-  import { flip } from "svelte/animate";
-  import type {
-    FocusEventHandler,
-    KeyboardEventHandler,
-  } from "svelte/elements";
-  import { SvelteMap, SvelteSet } from "svelte/reactivity";
-  import { highlight_matches, get_uuid } from "./attachments";
-  import CircleSpinner from "./CircleSpinner.svelte";
-  import Icon from "./Icon.svelte";
-  import type {
-    GroupedOptions,
-    KeyboardShortcuts,
-    MultiSelectProps,
-  } from "./types";
-  import {
-    fuzzy_match,
-    get_label,
-    get_style,
-    has_group,
-    is_object,
-  } from "./utils";
-  import Wiggle from "./Wiggle.svelte";
+  import { tick, untrack } from 'svelte'
+  import { flip } from 'svelte/animate'
+  import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+  import { get_uuid, highlight_matches } from './attachments'
+  import CircleSpinner from './CircleSpinner.svelte'
+  import Icon from './Icon.svelte'
+  import type { GroupedOptions, KeyboardShortcuts, MultiSelectProps } from './types'
+  import { fuzzy_match, get_label, get_style, has_group, is_object } from './utils'
+  import Wiggle from './Wiggle.svelte'
 
   let {
     activeIndex = $bindable(null),
@@ -41,11 +28,11 @@
     keepSelectedInDropdown = false,
     key = (opt) => `${get_label(opt)}`.toLowerCase(),
     filterFunc = (opt, searchText) => {
-      if (!searchText) return true;
-      const label = `${get_label(opt)}`;
+      if (!searchText) return true
+      const label = `${get_label(opt)}`
       return fuzzy
         ? fuzzy_match(searchText, label)
-        : label.toLowerCase().includes(searchText.toLowerCase());
+        : label.toLowerCase().includes(searchText.toLowerCase())
     },
     fuzzy = true,
     closeDropdownOnSelect = false,
@@ -88,15 +75,12 @@
     value = $bindable(null),
     selected = $bindable(
       value !== null && value !== undefined
-        ? Array.isArray(value)
-          ? value
-          : [value]
+        ? Array.isArray(value) ? value : [value]
         : (options
-            ?.filter(
-              (opt) =>
-                typeof opt === `object` && opt !== null && opt?.preselected,
-            )
-            .slice(0, maxSelect ?? undefined) ?? []),
+          ?.filter(
+            (opt) => typeof opt === `object` && opt !== null && opt?.preselected,
+          )
+          .slice(0, maxSelect ?? undefined) ?? []),
     ),
     sortSelected = false,
     selectedOptionsDraggable = !sortSelected,
@@ -168,55 +152,55 @@
     // Keyboard shortcuts for common actions
     shortcuts = {},
     ...rest
-  }: MultiSelectProps<Option> = $props();
+  }: MultiSelectProps<Option> = $props()
 
   // Generate unique IDs for ARIA associations (combobox pattern)
   // Uses provided id prop or generates a random one using crypto API
-  const internal_id = $derived(id ?? `sms-${get_uuid().slice(0, 8)}`);
-  const listbox_id = $derived(`${internal_id}-listbox`);
+  const internal_id = $derived(id ?? `sms-${get_uuid().slice(0, 8)}`)
+  const listbox_id = $derived(`${internal_id}-listbox`)
 
   // Parse shortcut string into modifier+key parts
   function parse_shortcut(shortcut: string): {
-    key: string;
-    ctrl: boolean;
-    shift: boolean;
-    alt: boolean;
-    meta: boolean;
+    key: string
+    ctrl: boolean
+    shift: boolean
+    alt: boolean
+    meta: boolean
   } {
     const parts = shortcut
       .toLowerCase()
       .split(`+`)
-      .map((part) => part.trim());
-    const key = parts.pop() ?? ``;
+      .map((part) => part.trim())
+    const key = parts.pop() ?? ``
     return {
       key,
       ctrl: parts.includes(`ctrl`),
       shift: parts.includes(`shift`),
       alt: parts.includes(`alt`),
       meta: parts.includes(`meta`) || parts.includes(`cmd`),
-    };
+    }
   }
 
   function matches_shortcut(
     event: KeyboardEvent,
     shortcut: string | null | undefined,
   ): boolean {
-    if (!shortcut) return false;
-    const parsed = parse_shortcut(shortcut);
+    if (!shortcut) return false
+    const parsed = parse_shortcut(shortcut)
     // Require non-empty key to prevent "ctrl+" from matching any key with ctrl pressed
-    if (!parsed.key) return false;
-    const key_matches = event.key.toLowerCase() === parsed.key;
-    const ctrl_matches = event.ctrlKey === parsed.ctrl;
-    const shift_matches = event.shiftKey === parsed.shift;
-    const alt_matches = event.altKey === parsed.alt;
-    const meta_matches = event.metaKey === parsed.meta;
+    if (!parsed.key) return false
+    const key_matches = event.key.toLowerCase() === parsed.key
+    const ctrl_matches = event.ctrlKey === parsed.ctrl
+    const shift_matches = event.shiftKey === parsed.shift
+    const alt_matches = event.altKey === parsed.alt
+    const meta_matches = event.metaKey === parsed.meta
     return (
       key_matches &&
       ctrl_matches &&
       shift_matches &&
       alt_matches &&
       meta_matches
-    );
+    )
   }
 
   // Default shortcuts
@@ -225,132 +209,128 @@
     clear_all: `ctrl+shift+a`,
     open: null,
     close: null,
-  };
+  }
 
   const effective_shortcuts = $derived({
     ...default_shortcuts,
     ...shortcuts,
-  });
+  })
 
   // Extract loadOptions config into single derived object (supports both simple function and config object)
   const load_options_config = $derived.by(() => {
-    if (!loadOptions) return null;
-    const is_fn = typeof loadOptions === `function`;
+    if (!loadOptions) return null
+    const is_fn = typeof loadOptions === `function`
     return {
       fetch: is_fn ? loadOptions : loadOptions.fetch,
       debounce_ms: is_fn ? 300 : (loadOptions.debounceMs ?? 300),
       batch_size: is_fn ? 50 : (loadOptions.batchSize ?? 50),
       on_open: is_fn ? true : (loadOptions.onOpen ?? true),
-    };
-  });
+    }
+  })
 
   // Helper to compare arrays/values for equality to avoid unnecessary updates.
   // Prevents infinite loops when value/selected are bound to reactive wrappers
   // that clone arrays on assignment (e.g. Superforms, Svelte stores). See issue #309.
   // Treats null/undefined/[] as equivalent empty states to prevent extra updates on init (#369).
   function values_equal(val1: unknown, val2: unknown): boolean {
-    if (val1 === val2) return true;
-    const empty1 = val1 == null || (Array.isArray(val1) && val1.length === 0);
-    const empty2 = val2 == null || (Array.isArray(val2) && val2.length === 0);
-    if (empty1 && empty2) return true;
+    if (val1 === val2) return true
+    const empty1 = val1 == null || (Array.isArray(val1) && val1.length === 0)
+    const empty2 = val2 == null || (Array.isArray(val2) && val2.length === 0)
+    if (empty1 && empty2) return true
     if (Array.isArray(val1) && Array.isArray(val2)) {
       return (
         val1.length === val2.length &&
         val1.every((item, idx) => item === val2[idx])
-      );
+      )
     }
-    return false;
+    return false
   }
 
   // Sync selected ↔ value bidirectionally. Use untrack to prevent each effect from
   // reacting to changes in the "destination" value, and values_equal to prevent
   // infinite loops with reactive wrappers that clone arrays. See issue #309.
   $effect.pre(() => {
-    const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected;
+    const new_value = maxSelect === 1 ? (selected[0] ?? null) : selected
     if (
       !values_equal(
         untrack(() => value),
         new_value,
       )
-    )
-      value = new_value;
-  });
+    ) {
+      value = new_value
+    }
+  })
   $effect.pre(() => {
-    const new_selected =
-      maxSelect === 1
-        ? value
-          ? [value as Option]
-          : []
-        : Array.isArray(value)
-          ? value
-          : [];
+    const new_selected = maxSelect === 1
+      ? (value ? [value as Option] : [])
+      : (Array.isArray(value) ? value : [])
     if (
       !values_equal(
         untrack(() => selected),
         new_selected,
       )
-    )
-      selected = new_selected;
-  });
+    ) {
+      selected = new_selected
+    }
+  })
 
-  let wiggle = $state(false); // controls wiggle animation when user tries to exceed maxSelect
-  let ignore_hover = $state(false); // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
+  let wiggle = $state(false) // controls wiggle animation when user tries to exceed maxSelect
+  let ignore_hover = $state(false) // ignore mouseover during keyboard navigation to prevent scroll-triggered hover
 
   // Track last selection action for aria-live announcements
-  let last_action = $state<{
-    type: `add` | `remove` | `removeAll`;
-    label: string;
-  } | null>(null);
+  let last_action = $state<
+    { type: `add` | `remove` | `removeAll`; label: string } | null
+  >(null)
 
   // Clear last_action after announcement so option counts can be announced again
   $effect(() => {
     if (last_action) {
-      const timer = setTimeout(() => (last_action = null), 1000);
-      return () => clearTimeout(timer);
+      const timer = setTimeout(() => (last_action = null), 1000)
+      return () => clearTimeout(timer)
     }
-  });
+  })
 
   // Debounced onsearch event - fires 150ms after search text stops changing
-  let search_debounce_timer: ReturnType<typeof setTimeout> | null = null;
-  let search_initialized = false;
+  let search_debounce_timer: ReturnType<typeof setTimeout> | null = null
+  let search_initialized = false
   $effect(() => {
-    const current_search = searchText;
+    const current_search = searchText
     // Skip initial mount - only fire on actual user input
     if (!search_initialized) {
-      search_initialized = true;
-      return;
+      search_initialized = true
+      return
     }
-    if (!onsearch) return; // cleanup handles any pending timer
+    if (!onsearch) return // cleanup handles any pending timer
 
     search_debounce_timer = setTimeout(() => {
       // Optional chaining in case onsearch is removed while timer is pending
       onsearch?.({
         searchText: current_search,
         matchingCount: matchingOptions.length,
-      });
-    }, 150);
+      })
+    }, 150)
     return () => {
-      if (search_debounce_timer) clearTimeout(search_debounce_timer);
-    };
-  });
+      if (search_debounce_timer) clearTimeout(search_debounce_timer)
+    }
+  })
 
   // Internal state for loadOptions feature (null = never loaded)
-  let loaded_options = $state<Option[]>([]);
-  let load_options_has_more = $state(true);
-  let load_options_loading = $state(false);
-  let load_options_last_search: string | null = $state(null);
-  let debounce_timer: ReturnType<typeof setTimeout> | null = null;
+  let loaded_options = $state<Option[]>([])
+  let load_options_has_more = $state(true)
+  let load_options_loading = $state(false)
+  let load_options_last_search: string | null = $state(null)
+  let debounce_timer: ReturnType<typeof setTimeout> | null = null
 
   let effective_options = $derived(
     loadOptions ? loaded_options : (options ?? []),
-  );
+  )
 
   // Cache selected keys and labels to avoid repeated .map() calls
-  let selected_keys = $derived(selected.map(key));
-  let selected_labels = $derived(selected.map(get_label));
+  let selected_keys = $derived(selected.map(key))
+  let selected_labels = $derived(selected.map(get_label))
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
-  let selected_keys_set = $derived(new Set(selected_keys));
-  let selected_labels_set = $derived(new Set(selected_labels));
+  let selected_keys_set = $derived(new Set(selected_keys))
+  let selected_labels_set = $derived(new Set(selected_labels))
 
   // Memoized Set of disabled option keys for O(1) lookups in large option sets
   let disabled_option_keys = $derived(
@@ -359,25 +339,25 @@
         .filter((opt) => is_object(opt) && opt.disabled)
         .map(key),
     ),
-  );
+  )
 
   // Check if an option is disabled (uses memoized Set for O(1) lookup)
-  const is_disabled = (opt: Option) => disabled_option_keys.has(key(opt));
+  const is_disabled = (opt: Option) => disabled_option_keys.has(key(opt))
 
   // Group matching options by their `group` key
   // Note: SvelteMap used here to satisfy eslint svelte/prefer-svelte-reactivity rule,
   // though a plain Map would work since this is recreated fresh on each derivation
   let grouped_options = $derived.by((): GroupedOptions<Option>[] => {
-    const groups_map = new SvelteMap<string, Option[]>();
-    const ungrouped: Option[] = [];
+    const groups_map = new SvelteMap<string, Option[]>()
+    const ungrouped: Option[] = []
 
     for (const opt of matchingOptions) {
       if (has_group(opt)) {
-        const existing = groups_map.get(opt.group);
-        if (existing) existing.push(opt);
-        else groups_map.set(opt.group, [opt]);
+        const existing = groups_map.get(opt.group)
+        if (existing) existing.push(opt)
+        else groups_map.set(opt.group, [opt])
       } else {
-        ungrouped.push(opt);
+        ungrouped.push(opt)
       }
     }
 
@@ -385,186 +365,186 @@
       group,
       options,
       collapsed: collapsedGroups.has(group),
-    }));
+    }))
 
     // Apply group sorting if specified
     if (groupSortOrder && groupSortOrder !== `none`) {
       grouped = grouped.toSorted((group_a, group_b) => {
         if (typeof groupSortOrder === `function`) {
-          return groupSortOrder(group_a.group, group_b.group);
+          return groupSortOrder(group_a.group, group_b.group)
         }
-        const cmp = group_a.group.localeCompare(group_b.group);
-        return groupSortOrder === `desc` ? -cmp : cmp;
-      });
+        const cmp = group_a.group.localeCompare(group_b.group)
+        return groupSortOrder === `desc` ? -cmp : cmp
+      })
     }
 
-    if (ungrouped.length === 0) return grouped;
+    if (ungrouped.length === 0) return grouped
 
     const ungrouped_entry = {
       group: null,
       options: ungrouped,
       collapsed: false,
-    };
+    }
     return ungroupedPosition === `first`
       ? [ungrouped_entry, ...grouped]
-      : [...grouped, ungrouped_entry];
-  });
+      : [...grouped, ungrouped_entry]
+  })
 
   // Flattened options for navigation (excludes options in collapsed groups)
   let navigable_options = $derived(
     grouped_options.flatMap(({ options: group_opts, collapsed }) =>
-      collapsed && collapsibleGroups ? [] : group_opts,
+      collapsed && collapsibleGroups ? [] : group_opts
     ),
-  );
+  )
 
   // Pre-computed Map for O(1) index lookups (avoids O(n²) in template)
   let navigable_index_map = $derived(
     new Map(navigable_options.map((opt, idx) => [opt, idx])),
-  );
+  )
 
   // Pre-computed group header state (avoids repeated calculations in template)
-  type GroupHeaderState = { all_selected: boolean; selected_count: number };
+  type GroupHeaderState = { all_selected: boolean; selected_count: number }
   let group_header_state = $derived.by(() => {
-    const state = new SvelteMap<string, GroupHeaderState>();
+    const state = new SvelteMap<string, GroupHeaderState>()
     for (const { group, options: opts, collapsed } of grouped_options) {
-      if (group === null) continue;
-      const selectable = get_selectable_opts(opts, collapsed);
-      const all_selected =
-        selectable.length > 0 &&
-        selectable.every((opt) => selected_keys_set.has(key(opt)));
+      if (group === null) continue
+      const selectable = get_selectable_opts(opts, collapsed)
+      const all_selected = selectable.length > 0 &&
+        selectable.every((opt) => selected_keys_set.has(key(opt)))
       // Count selected options (only needed when keepSelectedInDropdown is enabled)
-      let selected_count = 0;
+      let selected_count = 0
       if (keepSelectedInDropdown) {
         for (const opt of opts) {
-          if (selected_keys_set.has(key(opt))) selected_count++;
+          if (selected_keys_set.has(key(opt))) selected_count++
         }
       }
-      state.set(group, { all_selected, selected_count });
+      state.set(group, { all_selected, selected_count })
     }
-    return state;
-  });
+    return state
+  })
 
   // Update collapsedGroups state: 'add' adds groups, 'delete' removes groups, 'set' replaces all
   function update_collapsed_groups(
     action: `add` | `delete` | `set`,
     groups: string | Iterable<string>,
   ) {
-    const items = typeof groups === `string` ? [groups] : [...groups];
-    if (action === `set`) collapsedGroups = new SvelteSet(items);
+    const items = typeof groups === `string` ? [groups] : [...groups]
+    if (action === `set`) collapsedGroups = new SvelteSet(items)
     else {
-      const updated = new SvelteSet(collapsedGroups);
-      for (const group of items) updated[action](group);
-      collapsedGroups = updated;
+      const updated = new SvelteSet(collapsedGroups)
+      for (const group of items) updated[action](group)
+      collapsedGroups = updated
     }
   }
 
   // Toggle group collapsed state
   function toggle_group_collapsed(group_name: string) {
-    const was_collapsed = collapsedGroups.has(group_name);
-    update_collapsed_groups(was_collapsed ? `delete` : `add`, group_name);
-    ongroupToggle?.({ group: group_name, collapsed: !was_collapsed });
+    const was_collapsed = collapsedGroups.has(group_name)
+    update_collapsed_groups(was_collapsed ? `delete` : `add`, group_name)
+    ongroupToggle?.({ group: group_name, collapsed: !was_collapsed })
   }
 
   // Collapse/expand all groups (exposed via bindable props)
   collapseAllGroups = () => {
     const groups = grouped_options
       .map((entry) => entry.group)
-      .filter((group_name): group_name is string => group_name !== null);
-    if (groups.length === 0) return;
-    update_collapsed_groups(`set`, groups);
-    oncollapseAll?.({ groups });
-  };
+      .filter((group_name): group_name is string => group_name !== null)
+    if (groups.length === 0) return
+    update_collapsed_groups(`set`, groups)
+    oncollapseAll?.({ groups })
+  }
   expandAllGroups = () => {
-    const groups = [...collapsedGroups];
-    if (groups.length === 0) return;
-    update_collapsed_groups(`set`, []);
-    onexpandAll?.({ groups });
-  };
+    const groups = [...collapsedGroups]
+    if (groups.length === 0) return
+    update_collapsed_groups(`set`, [])
+    onexpandAll?.({ groups })
+  }
 
   // Expand specified groups and fire ongroupToggle for each
   function expand_groups(groups_to_expand: string[]) {
-    if (groups_to_expand.length === 0) return;
-    update_collapsed_groups(`delete`, groups_to_expand);
-    for (const group of groups_to_expand)
-      ongroupToggle?.({ group, collapsed: false });
+    if (groups_to_expand.length === 0) return
+    update_collapsed_groups(`delete`, groups_to_expand)
+    for (const group of groups_to_expand) {
+      ongroupToggle?.({ group, collapsed: false })
+    }
   }
 
   // Get names of collapsed groups that have matching options
   const get_collapsed_with_matches = () =>
     grouped_options.flatMap(({ group, collapsed, options: opts }) =>
-      group && collapsed && opts.length > 0 ? [group] : [],
-    );
+      group && collapsed && opts.length > 0 ? [group] : []
+    )
 
   // Auto-expand collapsed groups when search matches their options
   $effect(() => {
     if (searchExpandsCollapsedGroups && searchText && collapsibleGroups) {
-      expand_groups(get_collapsed_with_matches());
+      expand_groups(get_collapsed_with_matches())
     }
-  });
+  })
 
   // Normalize placeholder prop (supports string or { text, persistent } object)
   const placeholder_text = $derived(
     typeof placeholder === `string` ? placeholder : (placeholder?.text ?? null),
-  );
+  )
   const placeholder_persistent = $derived(
     typeof placeholder === `object` && placeholder?.persistent === true,
-  );
+  )
 
   // Helper to sort selected options (used by add() and select_all())
   function sort_selected(items: Option[]): Option[] {
     if (sortSelected === true) {
       return items.toSorted((op1, op2) =>
-        `${get_label(op1)}`.localeCompare(`${get_label(op2)}`),
-      );
+        `${get_label(op1)}`.localeCompare(`${get_label(op2)}`)
+      )
     } else if (typeof sortSelected === `function`) {
-      return items.toSorted(sortSelected);
+      return items.toSorted(sortSelected)
     }
-    return items;
+    return items
   }
 
   untrack(() => {
     if (!loadOptions && !((options?.length ?? 0) > 0)) {
       if (allowUserOptions || loading || disabled || allowEmpty) {
-        options = []; // initializing as array avoids errors when component mounts
+        options = [] // initializing as array avoids errors when component mounts
       } else {
         // error on empty options if user is not allowed to create custom options and loading is false
         // and component is not disabled and allowEmpty is false
-        console.error(`MultiSelect: received no options`);
+        console.error(`MultiSelect: received no options`)
       }
     }
-  });
+  })
   if (maxSelect !== null && maxSelect < 1) {
     console.error(
       `MultiSelect: maxSelect must be null or positive integer, got ${maxSelect}`,
-    );
+    )
   }
   if (!Array.isArray(selected)) {
     console.error(
       `MultiSelect: selected prop should always be an array, got ${selected}`,
-    );
+    )
   }
   $effect(() => {
     if (maxSelect && typeof required === `number` && required > maxSelect) {
       console.error(
         `MultiSelect: maxSelect=${maxSelect} < required=${required}, makes it impossible for users to submit a valid form`,
-      );
+      )
     }
     if (parseLabelsAsHtml && allowUserOptions) {
       console.warn(
         `MultiSelect: don't combine parseLabelsAsHtml and allowUserOptions. It's susceptible to XSS attacks!`,
-      );
+      )
     }
     if (sortSelected && selectedOptionsDraggable) {
       console.warn(
         `MultiSelect: sortSelected and selectedOptionsDraggable should not be combined as any ` +
           `user re-orderings of selected options will be undone by sortSelected on component re-renders.`,
-      );
+      )
     }
     if (allowUserOptions && !createOptionMsg && createOptionMsg !== null) {
       console.error(
         `MultiSelect: allowUserOptions=${allowUserOptions} but createOptionMsg=${createOptionMsg} is falsy. ` +
           `This prevents the "Add option" <span> from showing up, resulting in a confusing user experience.`,
-      );
+      )
     }
     if (
       maxOptions &&
@@ -572,91 +552,90 @@
     ) {
       console.error(
         `MultiSelect: maxOptions must be undefined or a positive integer, got ${maxOptions}`,
-      );
+      )
     }
-  });
+  })
 
-  let option_msg_is_active = $state(false); // controls active state of <li>{createOptionMsg}</li>
-  let window_width = $state(0);
+  let option_msg_is_active = $state(false) // controls active state of <li>{createOptionMsg}</li>
+  let window_width = $state(0)
 
   // Check if option matches search text (label or optionally group name)
   const matches_search = (opt: Option, search: string): boolean => {
-    if (filterFunc(opt, search)) return true;
+    if (filterFunc(opt, search)) return true
     if (searchMatchesGroups && search && has_group(opt)) {
       return fuzzy
         ? fuzzy_match(search, opt.group)
-        : opt.group.toLowerCase().includes(search.toLowerCase());
+        : opt.group.toLowerCase().includes(search.toLowerCase())
     }
-    return false;
-  };
+    return false
+  }
 
   $effect.pre(() => {
     // When using loadOptions, server handles filtering, so skip client-side filterFunc
     matchingOptions = effective_options.filter((opt) => {
       // Check if option is already selected and should be excluded
-      const keep_in_list =
-        !selected_keys_set.has(key(opt)) ||
+      const keep_in_list = !selected_keys_set.has(key(opt)) ||
         duplicates ||
-        keepSelectedInDropdown;
-      if (!keep_in_list) return false;
+        keepSelectedInDropdown
+      if (!keep_in_list) return false
 
       // When using loadOptions, server handles filtering; otherwise check search match
-      return loadOptions || matches_search(opt, searchText);
-    });
-  });
+      return loadOptions || matches_search(opt, searchText)
+    })
+  })
 
   // reset activeIndex if out of bounds (can happen when options change while dropdown is open)
   $effect(() => {
     if (activeIndex !== null && !navigable_options[activeIndex]) {
-      activeIndex = null;
+      activeIndex = null
     }
-  });
+  })
 
   // update activeOption when activeIndex changes
   $effect(() => {
-    activeOption = navigable_options[activeIndex ?? -1] ?? null;
-  });
+    activeOption = navigable_options[activeIndex ?? -1] ?? null
+  })
 
   // Compute the ID of the currently active option for aria-activedescendant
   const active_option_id = $derived(
     activeIndex !== null && activeIndex < navigable_options.length
       ? `${internal_id}-opt-${activeIndex}`
       : undefined,
-  );
+  )
 
   // Helper to check if removing an option would violate minSelect constraint
   const can_remove = $derived(
     minSelect === null || selected.length > minSelect,
-  );
+  )
 
   // toggle an option between selected and unselected states (for keepSelectedInDropdown mode)
   function toggle_option(option_to_toggle: Option, event: Event) {
-    const is_currently_selected = selected_keys_set.has(key(option_to_toggle));
+    const is_currently_selected = selected_keys_set.has(key(option_to_toggle))
 
     if (is_currently_selected) {
-      if (can_remove) remove(option_to_toggle, event);
-    } else add(option_to_toggle, event);
+      if (can_remove) remove(option_to_toggle, event)
+    } else add(option_to_toggle, event)
   }
 
   // add an option to selected list
   function add(option_to_add: Option, event: Event) {
-    event.stopPropagation();
-    if (maxSelect !== null && selected.length >= maxSelect) wiggle = true;
+    event.stopPropagation()
+    if (maxSelect !== null && selected.length >= maxSelect) wiggle = true
     if (
       !isNaN(Number(option_to_add)) &&
       typeof selected_labels[0] === `number`
     ) {
-      option_to_add = Number(option_to_add) as Option; // convert to number if possible
+      option_to_add = Number(option_to_add) as Option // convert to number if possible
     }
 
-    const is_duplicate = selected_keys_set.has(key(option_to_add));
-    const max_reached =
-      maxSelect !== null && maxSelect !== 1 && selected.length >= maxSelect;
+    const is_duplicate = selected_keys_set.has(key(option_to_add))
+    const max_reached = maxSelect !== null && maxSelect !== 1 &&
+      selected.length >= maxSelect
     // Fire events for blocked add attempts
     if (max_reached) {
-      onmaxreached?.({ selected, maxSelect, attemptedOption: option_to_add });
+      onmaxreached?.({ selected, maxSelect, attemptedOption: option_to_add })
     }
-    if (is_duplicate && !duplicates) onduplicate?.({ option: option_to_add });
+    if (is_duplicate && !duplicates) onduplicate?.({ option: option_to_add })
 
     if (
       (maxSelect === null || maxSelect === 1 || selected.length < maxSelect) &&
@@ -673,116 +652,117 @@
         // a new option from the user-entered text
         if (typeof effective_options[0] === `object`) {
           // if 1st option is an object, we create new option as object to keep type homogeneity
-          option_to_add = { label: searchText } as Option;
+          option_to_add = { label: searchText } as Option
         } else {
           if (
             [`number`, `undefined`].includes(typeof effective_options[0]) &&
             !isNaN(Number(searchText))
           ) {
             // create new option as number if it parses to a number and 1st option is also number or missing
-            option_to_add = Number(searchText) as Option;
+            option_to_add = Number(searchText) as Option
           } else {
-            option_to_add = searchText as Option; // else create custom option as string
+            option_to_add = searchText as Option // else create custom option as string
           }
         }
         // Fire oncreate event for all user-created options, regardless of type
-        oncreate?.({ option: option_to_add });
+        oncreate?.({ option: option_to_add })
         if (allowUserOptions === `append`) {
           if (loadOptions) {
-            loaded_options = [...loaded_options, option_to_add];
+            loaded_options = [...loaded_options, option_to_add]
           } else {
-            options = [...(options ?? []), option_to_add];
+            options = [...(options ?? []), option_to_add]
           }
         }
       }
 
-      if (resetFilterOnAdd) searchText = ``; // reset search string on selection
+      if (resetFilterOnAdd) searchText = `` // reset search string on selection
       if ([``, undefined, null].includes(option_to_add as string | null)) {
-        console.error(`MultiSelect: encountered falsy option`, option_to_add);
-        return;
+        console.error(`MultiSelect: encountered falsy option`, option_to_add)
+        return
       }
       // for maxSelect = 1 we always replace current option with new one
-      if (maxSelect === 1) selected = [option_to_add];
+      if (maxSelect === 1) selected = [option_to_add]
       else {
-        selected = sort_selected([...selected, option_to_add]);
+        selected = sort_selected([...selected, option_to_add])
       }
 
-      clear_validity();
-      handle_dropdown_after_select(event);
-      last_action = { type: `add`, label: `${get_label(option_to_add)}` };
-      onadd?.({ option: option_to_add });
-      onchange?.({ option: option_to_add, type: `add` });
+      clear_validity()
+      handle_dropdown_after_select(event)
+      last_action = { type: `add`, label: `${get_label(option_to_add)}` }
+      onadd?.({ option: option_to_add })
+      onchange?.({ option: option_to_add, type: `add` })
     }
   }
 
   // remove an option from selected list
   function remove(option_to_drop: Option, event: Event) {
-    event.stopPropagation();
-    if (selected.length === 0) return;
+    event.stopPropagation()
+    if (selected.length === 0) return
 
-    const idx = selected.findIndex((opt) => key(opt) === key(option_to_drop));
-    let option_removed = selected[idx];
+    const idx = selected.findIndex((opt) => key(opt) === key(option_to_drop))
+    let option_removed = selected[idx]
 
     if (option_removed === undefined && allowUserOptions) {
       // if option with label could not be found but allowUserOptions is truthy,
       // assume it was created by user and create corresponding option object
       // on the fly for use as event payload
-      const is_object_option = typeof effective_options[0] === `object`;
+      const is_object_option = typeof effective_options[0] === `object`
       option_removed = (
         is_object_option ? { label: option_to_drop } : option_to_drop
-      ) as Option;
+      ) as Option
     }
     if (option_removed === undefined) {
       console.error(
-        `MultiSelect: can't remove option ${JSON.stringify(
-          option_to_drop,
-        )}, not found in selected list`,
-      );
-      return;
+        `MultiSelect: can't remove option ${
+          JSON.stringify(
+            option_to_drop,
+          )
+        }, not found in selected list`,
+      )
+      return
     }
 
-    selected = selected.filter((_, remove_idx) => remove_idx !== idx);
-    clear_validity();
-    last_action = { type: `remove`, label: `${get_label(option_removed)}` };
-    onremove?.({ option: option_removed });
-    onchange?.({ option: option_removed, type: `remove` });
+    selected = selected.filter((_, remove_idx) => remove_idx !== idx)
+    clear_validity()
+    last_action = { type: `remove`, label: `${get_label(option_removed)}` }
+    onremove?.({ option: option_removed })
+    onchange?.({ option: option_removed, type: `remove` })
   }
 
   function open_dropdown(event: Event) {
-    event.stopPropagation();
+    event.stopPropagation()
 
-    if (disabled) return;
-    open = true;
+    if (disabled) return
+    open = true
     if (!(event instanceof FocusEvent)) {
       // avoid double-focussing input when event that opened dropdown was already input FocusEvent
-      input?.focus();
+      input?.focus()
     }
-    onopen?.({ event });
+    onopen?.({ event })
   }
 
   function close_dropdown(event: Event, retain_focus = false) {
-    open = false;
-    if (!retain_focus) input?.blur();
-    activeIndex = null;
-    onclose?.({ event });
+    open = false
+    if (!retain_focus) input?.blur()
+    activeIndex = null
+    onclose?.({ event })
   }
 
   function clear_validity() {
-    invalid = false;
-    form_input?.setCustomValidity(``);
+    invalid = false
+    form_input?.setCustomValidity(``)
   }
 
   function handle_dropdown_after_select(event: Event) {
-    const reached_max = selected.length >= (maxSelect ?? Infinity);
-    const should_close =
-      closeDropdownOnSelect === true ||
+    const reached_max = selected.length >= (maxSelect ?? Infinity)
+    const should_close = closeDropdownOnSelect === true ||
       closeDropdownOnSelect === `retain-focus` ||
       (closeDropdownOnSelect === `if-mobile` &&
         window_width &&
-        window_width < breakpoint);
+        window_width < breakpoint)
     if (reached_max || should_close) {
-      close_dropdown(event, closeDropdownOnSelect === `retain-focus`);
-    } else input?.focus();
+      close_dropdown(event, closeDropdownOnSelect === `retain-focus`)
+    } else input?.focus()
   }
 
   // Check if a user message (create option, duplicate warning, no match) is visible
@@ -793,11 +773,11 @@
           (!duplicates && selected_labels_set.has(searchText)) ||
           (navigable_options.length === 0 && noMatchingOptionsMsg),
       ),
-  );
+  )
 
   // Handle arrow key navigation through options (uses navigable_options to skip collapsed groups)
   async function handle_arrow_navigation(direction: 1 | -1) {
-    ignore_hover = true;
+    ignore_hover = true
 
     // Auto-expand collapsed groups when keyboard navigating
     if (
@@ -805,8 +785,8 @@
       collapsibleGroups &&
       collapsedGroups.size > 0
     ) {
-      expand_groups(get_collapsed_with_matches());
-      await tick();
+      expand_groups(get_collapsed_with_matches())
+      await tick()
     }
 
     // toggle user message when no options match but user can create
@@ -815,51 +795,50 @@
       !navigable_options.length &&
       searchText.length > 0
     ) {
-      option_msg_is_active = !option_msg_is_active;
-      return;
+      option_msg_is_active = !option_msg_is_active
+      return
     }
-    if (activeIndex === null && !navigable_options.length) return; // nothing to navigate
+    if (activeIndex === null && !navigable_options.length) return // nothing to navigate
 
     // activate first option or navigate with wrap-around
     if (activeIndex === null) {
-      activeIndex = 0;
+      activeIndex = 0
     } else {
-      const total = navigable_options.length + (has_user_msg ? 1 : 0);
+      const total = navigable_options.length + (has_user_msg ? 1 : 0)
       // Guard against division by zero (can happen if options filtered away before effect resets activeIndex)
       if (total === 0) {
-        activeIndex = null;
-        return;
+        activeIndex = null
+        return
       }
-      activeIndex = (activeIndex + direction + total) % total; // +total handles negative mod
+      activeIndex = (activeIndex + direction + total) % total // +total handles negative mod
     }
 
     // update active state based on new index
-    option_msg_is_active =
-      has_user_msg && activeIndex === navigable_options.length;
+    option_msg_is_active = has_user_msg && activeIndex === navigable_options.length
     activeOption = option_msg_is_active
       ? null
-      : (navigable_options[activeIndex] ?? null);
+      : (navigable_options[activeIndex] ?? null)
 
     if (autoScroll) {
-      await tick();
+      await tick()
       document
         .querySelector(`ul.options > li.active`)
-        ?.scrollIntoViewIfNeeded?.();
+        ?.scrollIntoViewIfNeeded?.()
     }
 
     // Fire onactivate for keyboard navigation only (not mouse hover)
-    onactivate?.({ option: activeOption, index: activeIndex });
+    onactivate?.({ option: activeOption, index: activeIndex })
   }
 
   // handle all keyboard events this component receives
   async function handle_keydown(event: KeyboardEvent) {
-    if (disabled) return; // Block all keyboard handling when disabled
+    if (disabled) return // Block all keyboard handling when disabled
 
     // Check keyboard shortcuts first (before other key handling)
     const shortcut_actions: Array<{
-      key: keyof typeof effective_shortcuts;
-      condition: () => boolean;
-      action: () => void;
+      key: keyof typeof effective_shortcuts
+      condition: () => boolean
+      action: () => void
     }> = [
       {
         key: `select_all`,
@@ -881,124 +860,124 @@
         key: `close`,
         condition: () => open,
         action: () => {
-          close_dropdown(event);
-          searchText = ``;
+          close_dropdown(event)
+          searchText = ``
         },
       },
-    ];
+    ]
 
     for (const { key, condition, action } of shortcut_actions) {
       if (matches_shortcut(event, effective_shortcuts[key]) && condition()) {
-        event.preventDefault();
-        event.stopPropagation();
-        action();
-        return;
+        event.preventDefault()
+        event.stopPropagation()
+        action()
+        return
       }
     }
 
     // on escape or tab out of input: close options dropdown and reset search text
     if (event.key === `Escape` || event.key === `Tab`) {
-      event.stopPropagation();
-      close_dropdown(event);
-      searchText = ``;
+      event.stopPropagation()
+      close_dropdown(event)
+      searchText = ``
     } // on enter key: toggle active option
     else if (event.key === `Enter`) {
-      event.stopPropagation();
-      event.preventDefault(); // prevent enter key from triggering form submission
+      event.stopPropagation()
+      event.preventDefault() // prevent enter key from triggering form submission
 
       if (activeOption) {
         if (selected_keys_set.has(key(activeOption))) {
-          if (can_remove) remove(activeOption, event);
-        } else add(activeOption, event); // add() handles resetFilterOnAdd internally when successful
+          if (can_remove) remove(activeOption, event)
+        } else add(activeOption, event) // add() handles resetFilterOnAdd internally when successful
       } else if (allowUserOptions && searchText.length > 0) {
         // user entered text but no options match, so if allowUserOptions is truthy, we create new option
-        add(searchText as Option, event);
+        add(searchText as Option, event)
       } else {
         // no active option and no search text means the options dropdown is closed
         // in which case enter means open it
-        open_dropdown(event);
+        open_dropdown(event)
       }
     } // on up/down arrow keys: update active option
     else if (event.key === `ArrowDown` || event.key === `ArrowUp`) {
-      event.stopPropagation();
-      event.preventDefault();
-      await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1);
+      event.stopPropagation()
+      event.preventDefault()
+      await handle_arrow_navigation(event.key === `ArrowUp` ? -1 : 1)
     } // on backspace key: remove last selected option
     else if (event.key === `Backspace` && selected.length > 0 && !searchText) {
-      event.stopPropagation();
+      event.stopPropagation()
       if (can_remove) {
-        const last_option = selected.at(-1);
-        if (last_option) remove(last_option, event);
+        const last_option = selected.at(-1)
+        if (last_option) remove(last_option, event)
       }
       // Don't prevent default, allow normal backspace behavior if not removing
     } // make first matching option active on any keypress (if none of the above special cases match)
     else if (navigable_options.length > 0 && activeIndex === null) {
       // Don't stop propagation or prevent default here, allow normal character input
-      activeIndex = 0;
+      activeIndex = 0
     }
   }
 
   function remove_all(event: Event) {
-    event.stopPropagation();
+    event.stopPropagation()
 
     // Keep the first minSelect items, remove the rest
-    let removed_options: Option[] = [];
+    let removed_options: Option[] = []
     if (minSelect === null) {
       // If no minSelect constraint, remove all
-      removed_options = selected;
-      selected = [];
+      removed_options = selected
+      selected = []
     } else if (selected.length > minSelect) {
       // Keep the first minSelect items
-      removed_options = selected.slice(minSelect);
-      selected = selected.slice(0, minSelect);
+      removed_options = selected.slice(minSelect)
+      selected = selected.slice(0, minSelect)
     }
     // Only fire events if something was actually removed
     if (removed_options.length > 0) {
-      searchText = ``; // always clear on remove all (resetFilterOnAdd only applies to add operations)
+      searchText = `` // always clear on remove all (resetFilterOnAdd only applies to add operations)
       last_action = {
         type: `removeAll`,
         label: `${removed_options.length} options`,
-      };
-      onremoveAll?.({ options: removed_options });
-      onchange?.({ options: selected, type: `removeAll` });
+      }
+      onremoveAll?.({ options: removed_options })
+      onchange?.({ options: selected, type: `removeAll` })
     }
   }
 
   // Check if option index is within maxOptions visibility limit
   const is_option_visible = (idx: number) =>
-    idx >= 0 && (maxOptions == null || idx < maxOptions);
+    idx >= 0 && (maxOptions == null || idx < maxOptions)
 
   // Get non-disabled, selectable options from a list
   // For collapsed groups: returns all non-disabled options (user explicitly wants this group)
   // For expanded groups/top-level: respects maxOptions rendering limit
   const get_selectable_opts = (opts: Option[], skip_visibility_check = false) =>
     opts.filter((opt) => {
-      if (is_disabled(opt)) return false;
-      if (skip_visibility_check) return true;
-      return is_option_visible(navigable_index_map.get(opt) ?? -1);
-    });
+      if (is_disabled(opt)) return false
+      if (skip_visibility_check) return true
+      return is_option_visible(navigable_index_map.get(opt) ?? -1)
+    })
 
   // Batch-add options to selection with all side effects (used by select_all and group select)
   function batch_add_options(options_to_add: Option[], event: Event) {
-    const remaining = Math.max(0, (maxSelect ?? Infinity) - selected.length);
+    const remaining = Math.max(0, (maxSelect ?? Infinity) - selected.length)
     const to_add = options_to_add
       .filter((opt) => !selected_keys_set.has(key(opt)))
-      .slice(0, remaining);
+      .slice(0, remaining)
 
-    if (to_add.length === 0) return;
+    if (to_add.length === 0) return
 
-    selected = sort_selected([...selected, ...to_add]);
-    if (resetFilterOnAdd) searchText = ``;
-    clear_validity();
-    handle_dropdown_after_select(event);
-    onselectAll?.({ options: to_add });
-    onchange?.({ options: selected, type: `selectAll` });
+    selected = sort_selected([...selected, ...to_add])
+    if (resetFilterOnAdd) searchText = ``
+    clear_validity()
+    handle_dropdown_after_select(event)
+    onselectAll?.({ options: to_add })
+    onchange?.({ options: selected, type: `selectAll` })
   }
 
   // Batch-add options for top-level "Select all" (only visible/navigable options)
   function select_all(event: Event) {
-    event.stopPropagation();
-    batch_add_options(get_selectable_opts(navigable_options), event);
+    event.stopPropagation()
+    batch_add_options(get_selectable_opts(navigable_options), event)
   }
 
   // Toggle group selection: works even when group is collapsed
@@ -1009,34 +988,33 @@
     all_selected: boolean,
     event: Event,
   ) {
-    event.stopPropagation();
-    const selectable = get_selectable_opts(group_opts, group_collapsed);
+    event.stopPropagation()
+    const selectable = get_selectable_opts(group_opts, group_collapsed)
     if (all_selected) {
       // Deselect all options in this group
-      const keys_to_remove = new Set(selectable.map(key));
-      const removed = selected.filter((opt) => keys_to_remove.has(key(opt)));
-      selected = selected.filter((opt) => !keys_to_remove.has(key(opt)));
+      const keys_to_remove = new Set(selectable.map(key))
+      const removed = selected.filter((opt) => keys_to_remove.has(key(opt)))
+      selected = selected.filter((opt) => !keys_to_remove.has(key(opt)))
       if (removed.length > 0) {
-        onremoveAll?.({ options: removed });
-        onchange?.({ options: selected, type: `removeAll` });
+        onremoveAll?.({ options: removed })
+        onchange?.({ options: selected, type: `removeAll` })
       }
     } else {
       // Select all non-disabled, non-selected options in this group
-      batch_add_options(selectable, event);
+      batch_add_options(selectable, event)
     }
   }
 
   // O(1) lookup using pre-computed Set instead of O(n) array.includes()
-  const is_selected = (label: string | number) =>
-    selected_labels_set.has(label);
+  const is_selected = (label: string | number) => selected_labels_set.has(label)
 
   const if_enter_or_space =
     (handler: (event: KeyboardEvent) => void) => (event: KeyboardEvent) => {
       if (event.key === `Enter` || event.code === `Space`) {
-        event.preventDefault();
-        handler(event);
+        event.preventDefault()
+        handler(event)
       }
-    };
+    }
 
   // Handle option interaction (click or keyboard) - DRY helper for template
   const handle_option_interact = (
@@ -1044,153 +1022,154 @@
     opt_disabled: boolean | null,
     event: Event,
   ) => {
-    if (opt_disabled) return;
-    if (keepSelectedInDropdown) toggle_option(opt, event);
-    else add(opt, event);
-  };
-
-  function on_click_outside(event: MouseEvent | TouchEvent) {
-    if (!outerDiv) return;
-    const target = event.target as Node;
-    // Check if click is inside the main component
-    if (outerDiv.contains(target)) return;
-    // If portal is active, also check if click is inside the portalled options dropdown
-    if (portal_params?.active && ul_options && ul_options.contains(target))
-      return;
-    // Click is outside both the main component and any portalled dropdown
-    close_dropdown(event);
+    if (opt_disabled) return
+    if (keepSelectedInDropdown) toggle_option(opt, event)
+    else add(opt, event)
   }
 
-  let drag_idx: number | null = $state(null);
+  function on_click_outside(event: MouseEvent | TouchEvent) {
+    if (!outerDiv) return
+    const target = event.target as Node
+    // Check if click is inside the main component
+    if (outerDiv.contains(target)) return
+    // If portal is active, also check if click is inside the portalled options dropdown
+    if (portal_params?.active && ul_options && ul_options.contains(target)) {
+      return
+    }
+    // Click is outside both the main component and any portalled dropdown
+    close_dropdown(event)
+  }
+
+  let drag_idx: number | null = $state(null)
   // event handlers enable dragging to reorder selected options
   const drop = (target_idx: number) => (event: DragEvent) => {
-    if (!event.dataTransfer) return;
-    event.dataTransfer.dropEffect = `move`;
-    const start_idx = parseInt(event.dataTransfer.getData(`text/plain`));
-    const new_selected = [...selected];
+    if (!event.dataTransfer) return
+    event.dataTransfer.dropEffect = `move`
+    const start_idx = parseInt(event.dataTransfer.getData(`text/plain`))
+    const new_selected = [...selected]
 
     if (start_idx < target_idx) {
-      new_selected.splice(target_idx + 1, 0, new_selected[start_idx]);
-      new_selected.splice(start_idx, 1);
+      new_selected.splice(target_idx + 1, 0, new_selected[start_idx])
+      new_selected.splice(start_idx, 1)
     } else {
-      new_selected.splice(target_idx, 0, new_selected[start_idx]);
-      new_selected.splice(start_idx + 1, 1);
+      new_selected.splice(target_idx, 0, new_selected[start_idx])
+      new_selected.splice(start_idx + 1, 1)
     }
-    selected = new_selected;
-    drag_idx = null;
-    onreorder?.({ options: new_selected });
-    onchange?.({ options: new_selected, type: `reorder` });
-  };
+    selected = new_selected
+    drag_idx = null
+    onreorder?.({ options: new_selected })
+    onchange?.({ options: new_selected, type: `reorder` })
+  }
 
   const dragstart = (idx: number) => (event: DragEvent) => {
-    if (!event.dataTransfer) return;
+    if (!event.dataTransfer) return
     // only allow moving, not copying (also affects the cursor during drag)
-    event.dataTransfer.effectAllowed = `move`;
-    event.dataTransfer.dropEffect = `move`;
-    event.dataTransfer.setData(`text/plain`, `${idx}`);
-  };
+    event.dataTransfer.effectAllowed = `move`
+    event.dataTransfer.dropEffect = `move`
+    event.dataTransfer.setData(`text/plain`, `${idx}`)
+  }
 
-  let ul_options = $state<HTMLUListElement>();
+  let ul_options = $state<HTMLUListElement>()
 
   const handle_input_keydown: KeyboardEventHandler<HTMLInputElement> = (
     event,
   ) => {
-    handle_keydown(event); // Restore internal logic
+    handle_keydown(event) // Restore internal logic
     // Call original forwarded handler
-    onkeydown?.(event);
-  };
+    onkeydown?.(event)
+  }
 
   const handle_input_focus: FocusEventHandler<HTMLInputElement> = (event) => {
-    open_dropdown(event);
-    onfocus?.(event);
-  };
+    open_dropdown(event)
+    onfocus?.(event)
+  }
 
   // Override input's focus method to ensure dropdown opens on programmatic focus
   // https://github.com/janosh/svelte-multiselect/issues/289
   $effect(() => {
-    if (!input) return;
+    if (!input) return
 
-    const orig_focus = input.focus.bind(input);
+    const orig_focus = input.focus.bind(input)
 
     input.focus = (options?: FocusOptions) => {
-      orig_focus(options);
+      orig_focus(options)
       if (!disabled && !open) {
-        open_dropdown(new FocusEvent(`focus`, { bubbles: true }));
+        open_dropdown(new FocusEvent(`focus`, { bubbles: true }))
       }
-    };
+    }
 
     return () => {
-      if (input) input.focus = orig_focus;
-    };
-  });
+      if (input) input.focus = orig_focus
+    }
+  })
 
   const handle_input_blur: FocusEventHandler<HTMLInputElement> = (event) => {
     // For portalled dropdowns, don't close on blur since clicks on portalled elements
     // will cause blur but we want to allow the click to register first
     // (otherwise mobile touch event is unable to select options https://github.com/janosh/svelte-multiselect/issues/335)
     if (portal_params?.active) {
-      onblur?.(event); // Let the click handler manage closing for portalled dropdowns
-      return;
+      onblur?.(event) // Let the click handler manage closing for portalled dropdowns
+      return
     }
 
     // For non-portalled dropdowns, close when focus moves outside the component
-    if (!outerDiv?.contains(event.relatedTarget as Node)) close_dropdown(event);
+    if (!outerDiv?.contains(event.relatedTarget as Node)) close_dropdown(event)
 
-    onblur?.(event); // Call original handler (if any passed as component prop)
-  };
+    onblur?.(event) // Call original handler (if any passed as component prop)
+  }
 
   // reset form validation when required prop changes
   // https://github.com/janosh/svelte-multiselect/issues/285
   $effect.pre(() => {
-    required = required; // trigger effect when required changes
-    form_input?.setCustomValidity(``);
-  });
+    required = required // trigger effect when required changes
+    form_input?.setCustomValidity(``)
+  })
 
-  type PortalParams = { target_node: HTMLElement | null; active?: boolean };
+  type PortalParams = { target_node: HTMLElement | null; active?: boolean }
   function portal(node: HTMLElement, params: PortalParams) {
-    let { target_node, active } = params;
-    if (!active) return;
-    let render_in_place =
-      typeof window === `undefined` || !document.body.contains(node);
+    let { target_node, active } = params
+    if (!active) return
+    let render_in_place = typeof window === `undefined` ||
+      !document.body.contains(node)
 
     if (!render_in_place) {
-      document.body.appendChild(node);
-      node.style.position = `fixed`;
+      document.body.appendChild(node)
+      node.style.position = `fixed`
 
       const update_position = () => {
-        if (!target_node || !open) return (node.hidden = true);
-        const rect = target_node.getBoundingClientRect();
-        node.style.left = `${rect.left}px`;
-        node.style.top = `${rect.bottom}px`;
-        node.style.width = `${rect.width}px`;
-        node.hidden = false;
-      };
+        if (!target_node || !open) return (node.hidden = true)
+        const rect = target_node.getBoundingClientRect()
+        node.style.left = `${rect.left}px`
+        node.style.top = `${rect.bottom}px`
+        node.style.width = `${rect.width}px`
+        node.hidden = false
+      }
 
-      if (open) tick().then(update_position);
+      if (open) tick().then(update_position)
 
-      window.addEventListener(`scroll`, update_position, true);
-      window.addEventListener(`resize`, update_position);
+      window.addEventListener(`scroll`, update_position, true)
+      window.addEventListener(`resize`, update_position)
 
       $effect(() => {
-        if (open && target_node) update_position();
-        else node.hidden = true;
-      });
+        if (open && target_node) update_position()
+        else node.hidden = true
+      })
 
       return {
         update(params: PortalParams) {
-          target_node = params.target_node;
-          render_in_place =
-            typeof window === `undefined` || !document.body.contains(node);
-          if (open && !render_in_place && target_node)
-            tick().then(update_position);
-          else if (!open || !target_node) node.hidden = true;
+          target_node = params.target_node
+          render_in_place = typeof window === `undefined` ||
+            !document.body.contains(node)
+          if (open && !render_in_place && target_node) {
+            tick().then(update_position)
+          } else if (!open || !target_node) node.hidden = true
         },
         destroy() {
-          if (!render_in_place) node.remove();
-          window.removeEventListener(`scroll`, update_position, true);
-          window.removeEventListener(`resize`, update_position);
+          if (!render_in_place) node.remove()
+          window.removeEventListener(`scroll`, update_position, true)
+          window.removeEventListener(`resize`, update_position)
         },
-      };
+      }
     }
   }
 
@@ -1201,78 +1180,77 @@
       load_options_loading ||
       (!reset && !load_options_has_more)
     ) {
-      return;
+      return
     }
     // Capture search term at call time to avoid race with user typing during fetch
-    const search = searchText;
-    const offset = reset ? 0 : loaded_options.length;
-    load_options_loading = true;
+    const search = searchText
+    const offset = reset ? 0 : loaded_options.length
+    load_options_loading = true
     try {
-      const limit = load_options_config.batch_size;
-      const result = await load_options_config.fetch({ search, offset, limit });
-      loaded_options = reset
-        ? result.options
-        : [...loaded_options, ...result.options];
-      load_options_has_more = result.hasMore;
-      load_options_last_search = search;
+      const limit = load_options_config.batch_size
+      const result = await load_options_config.fetch({ search, offset, limit })
+      loaded_options = reset ? result.options : [...loaded_options, ...result.options]
+      load_options_has_more = result.hasMore
+      load_options_last_search = search
     } catch (err) {
-      console.error(`MultiSelect: loadOptions error:`, err);
+      console.error(`MultiSelect: loadOptions error:`, err)
     } finally {
-      load_options_loading = false;
+      load_options_loading = false
     }
   }
 
   // Single effect handles initial load + search changes
   $effect(() => {
-    if (!load_options_config) return;
+    if (!load_options_config) return
 
     // Reset state when dropdown closes so next open triggers fresh load
     if (!open) {
-      load_options_last_search = null;
-      loaded_options = [];
-      load_options_has_more = true;
-      return;
+      load_options_last_search = null
+      loaded_options = []
+      load_options_has_more = true
+      return
     }
 
-    if (debounce_timer) clearTimeout(debounce_timer);
+    if (debounce_timer) clearTimeout(debounce_timer)
 
-    const search = searchText;
-    const is_first_load = load_options_last_search === null;
+    const search = searchText
+    const is_first_load = load_options_last_search === null
 
     if (is_first_load) {
       if (load_options_config.on_open) {
         // Load immediately on dropdown open
-        load_dynamic_options(true);
+        load_dynamic_options(true)
       } else if (search) {
         // onOpen=false but user typed - debounce and load
         debounce_timer = setTimeout(
           () => load_dynamic_options(true),
           load_options_config.debounce_ms,
-        );
+        )
       }
       // If onOpen=false and no search text, do nothing (wait for user to type)
     } else if (search !== load_options_last_search) {
       // Subsequent loads: debounce search changes
       // Clear stale results immediately so UI doesn't show wrong results while loading
-      loaded_options = [];
-      load_options_has_more = true;
+      loaded_options = []
+      load_options_has_more = true
       debounce_timer = setTimeout(
         () => load_dynamic_options(true),
         load_options_config.debounce_ms,
-      );
+      )
     }
     return () => {
-      if (debounce_timer) clearTimeout(debounce_timer);
-    };
-  });
+      if (debounce_timer) clearTimeout(debounce_timer)
+    }
+  })
 
   function handle_options_scroll(event: Event) {
-    if (!load_options_config || load_options_loading || !load_options_has_more)
-      return;
-    const { scrollTop, scrollHeight, clientHeight } =
-      event.target as HTMLElement;
-    if (scrollHeight - scrollTop - clientHeight <= 100)
-      load_dynamic_options(false);
+    if (!load_options_config || load_options_loading || !load_options_has_more) {
+      return
+    }
+    const { scrollTop, scrollHeight, clientHeight } = event.target as HTMLElement
+    if (scrollHeight - scrollTop - clientHeight <= 100) {
+      load_dynamic_options(false)
+    }
   }
 </script>
 
@@ -1301,25 +1279,23 @@
   <input
     {name}
     required={Boolean(required)}
-    value={selected.length >= Number(required)
-      ? JSON.stringify(selected)
-      : null}
+    value={selected.length >= Number(required) ? JSON.stringify(selected) : null}
     tabindex="-1"
     aria-hidden="true"
     aria-label="ignore this, used only to prevent form submission if select is required but empty"
     class="form-control"
     bind:this={form_input}
     oninvalid={() => {
-      invalid = true;
-      let msg;
+      invalid = true
+      let msg
       if (maxSelect && maxSelect > 1 && Number(required) > 1) {
-        msg = `Please select between ${required} and ${maxSelect} options`;
+        msg = `Please select between ${required} and ${maxSelect} options`
       } else if (Number(required) > 1) {
-        msg = `Please select at least ${required} options`;
+        msg = `Please select at least ${required} options`
       } else {
-        msg = `Please select an option`;
+        msg = `Please select an option`
       }
-      form_input?.setCustomValidity(msg);
+      form_input?.setCustomValidity(msg)
     }}
   />
   <span class="expand-icon">
@@ -1338,10 +1314,9 @@
     style={ulSelectedStyle}
   >
     {#each selected as option, idx (duplicates ? `${key(option)}-${idx}` : key(option))}
-      {@const selectedOptionStyle =
-        [get_style(option, `selected`), liSelectedStyle]
-          .filter(Boolean)
-          .join(` `) || null}
+      {@const selectedOptionStyle = [get_style(option, `selected`), liSelectedStyle]
+        .filter(Boolean)
+        .join(` `) || null}
       <li
         class={liSelectedClass}
         role="option"
@@ -1350,7 +1325,7 @@
         draggable={selectedOptionsDraggable && !disabled && selected.length > 1}
         ondragstart={dragstart(idx)}
         ondragover={(event) => {
-          event.preventDefault(); // needed for ondrop to fire
+          event.preventDefault() // needed for ondrop to fire
         }}
         ondrop={drop(idx)}
         ondragenter={() => (drag_idx = idx)}
@@ -1359,15 +1334,9 @@
         onmouseup={(event) => event.stopPropagation()}
       >
         {#if selectedItem}
-          {@render selectedItem({
-            option,
-            idx,
-          })}
+          {@render selectedItem({ option, idx })}
         {:else if children}
-          {@render children({
-            option,
-            idx,
-          })}
+          {@render children({ option, idx })}
         {:else if parseLabelsAsHtml}
           {@html get_label(option)}
         {:else}
@@ -1400,9 +1369,7 @@
       {autocomplete}
       {inputmode}
       {pattern}
-      placeholder={selected.length === 0 || placeholder_persistent
-        ? placeholder_text
-        : null}
+      placeholder={selected.length === 0 || placeholder_persistent ? placeholder_text : null}
       role="combobox"
       aria-haspopup="listbox"
       aria-expanded={open}
@@ -1427,14 +1394,14 @@
       {...rest}
     />
     {@render afterInput?.({
-      selected,
-      disabled,
-      invalid,
-      id,
-      placeholder: placeholder_text,
-      open,
-      required,
-    })}
+        selected,
+        disabled,
+        invalid,
+        id,
+        placeholder: placeholder_text,
+        open,
+        required,
+      })}
   </ul>
   {#if loading}
     {#if spinner}
@@ -1480,7 +1447,8 @@
   {/if}
 
   <!-- only render options dropdown if options or searchText is not empty (needed to avoid briefly flashing empty dropdown) -->
-  {#if (searchText && noMatchingOptionsMsg) || effective_options.length > 0 || loadOptions}
+  {#if (searchText && noMatchingOptionsMsg) || effective_options.length > 0 ||
+      loadOptions}
     <ul
       use:portal={{ target_node: outerDiv, ...portal_params }}
       {@attach highlight_matches({
@@ -1506,9 +1474,9 @@
       onscroll={handle_options_scroll}
       onmousemove={() => (ignore_hover = false)}
     >
-      {#if selectAllOption && effective_options.length > 0 && (maxSelect === null || maxSelect > 1)}
-        {@const label =
-          typeof selectAllOption === `string` ? selectAllOption : `Select all`}
+      {#if selectAllOption && effective_options.length > 0 &&
+        (maxSelect === null || maxSelect > 1)}
+        {@const label = typeof selectAllOption === `string` ? selectAllOption : `Select all`}
         <li
           class="select-all {liSelectAllClass}"
           onclick={select_all}
@@ -1520,15 +1488,19 @@
           {label}
         </li>
       {/if}
-      {#each grouped_options as { group: group_name, options: group_opts, collapsed }, group_idx (group_name ?? `ungrouped-${group_idx}`)}
+      {#each grouped_options as
+        { group: group_name, options: group_opts, collapsed },
+        group_idx
+        (group_name ?? `ungrouped-${group_idx}`)
+      }
         {#if group_name !== null}
           {@const { all_selected, selected_count } = group_header_state.get(
-            group_name,
-          ) ?? { all_selected: false, selected_count: 0 }}
+        group_name,
+      ) ?? { all_selected: false, selected_count: 0 }}
           {@const handle_toggle = () =>
-            collapsibleGroups && toggle_group_collapsed(group_name)}
+        collapsibleGroups && toggle_group_collapsed(group_name)}
           {@const handle_group_select = (event: Event) =>
-            toggle_group_selection(group_opts, collapsed, all_selected, event)}
+        toggle_group_selection(group_opts, collapsed, all_selected, event)}
           <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
           <li
             class="group-header {liGroupHeaderClass}"
@@ -1543,11 +1515,7 @@
             tabindex={collapsibleGroups ? 0 : -1}
           >
             {#if groupHeader}
-              {@render groupHeader({
-                group: group_name,
-                options: group_opts,
-                collapsed,
-              })}
+              {@render groupHeader({ group: group_name, options: group_opts, collapsed })}
             {:else}
               <span class="group-label">{group_name}</span>
               <span class="group-count">
@@ -1578,38 +1546,40 @@
           </li>
         {/if}
         {#if !collapsed || !collapsibleGroups}
-          {#each group_opts as option_item, local_idx (duplicates ? `${key(option_item)}-${group_idx}-${local_idx}` : key(option_item))}
+          {#each group_opts as
+            option_item,
+            local_idx
+            (duplicates
+        ? `${key(option_item)}-${group_idx}-${local_idx}`
+        : key(option_item))
+          }
             {@const flat_idx = navigable_index_map.get(option_item) ?? -1}
             {@const {
-              label,
-              disabled = null,
-              title = null,
-              selectedTitle = null,
-              disabledTitle = defaultDisabledTitle,
-            } = is_object(option_item) ? option_item : { label: option_item }}
+        label,
+        disabled = null,
+        title = null,
+        selectedTitle = null,
+        disabledTitle = defaultDisabledTitle,
+      } = is_object(option_item) ? option_item : { label: option_item }}
             {@const active = activeIndex === flat_idx && flat_idx >= 0}
             {@const selected = is_selected(label)}
-            {@const optionStyle =
-              [get_style(option_item, `option`), liOptionStyle]
-                .filter(Boolean)
-                .join(` `) || null}
+            {@const optionStyle = [get_style(option_item, `option`), liOptionStyle]
+        .filter(Boolean)
+        .join(` `) || null}
             {#if is_option_visible(flat_idx)}
               <li
                 id="{internal_id}-opt-{flat_idx}"
-                onclick={(event) =>
-                  handle_option_interact(option_item, disabled, event)}
-                title={disabled
-                  ? disabledTitle
-                  : (selected && selectedTitle) || title}
+                onclick={(event) => handle_option_interact(option_item, disabled, event)}
+                title={disabled ? disabledTitle : (selected && selectedTitle) || title}
                 class:selected
                 class:active
                 class:disabled
                 class="{liOptionClass} {active ? liActiveOptionClass : ``}"
                 onmouseover={() => {
-                  if (!disabled && !ignore_hover) activeIndex = flat_idx;
+                  if (!disabled && !ignore_hover) activeIndex = flat_idx
                 }}
                 onfocus={() => {
-                  if (!disabled) activeIndex = flat_idx;
+                  if (!disabled) activeIndex = flat_idx
                 }}
                 role="option"
                 aria-selected={selected ? `true` : `false`}
@@ -1617,7 +1587,7 @@
                 aria-setsize={navigable_options.length}
                 style={optionStyle}
                 onkeydown={if_enter_or_space((event) =>
-                  handle_option_interact(option_item, disabled, event),
+                  handle_option_interact(option_item, disabled, event)
                 )}
               >
                 {#if keepSelectedInDropdown === `checkboxes`}
@@ -1630,15 +1600,9 @@
                   />
                 {/if}
                 {#if option}
-                  {@render option({
-                    option: option_item,
-                    idx: flat_idx,
-                  })}
+                  {@render option({ option: option_item, idx: flat_idx })}
                 {:else if children}
-                  {@render children({
-                    option: option_item,
-                    idx: flat_idx,
-                  })}
+                  {@render children({ option: option_item, idx: flat_idx })}
                 {:else if parseLabelsAsHtml}
                   {@html get_label(option_item)}
                 {:else}
@@ -1652,33 +1616,28 @@
       {#if searchText}
         {@const text_input_is_duplicate = selected_labels.includes(searchText)}
         {@const is_dupe = !duplicates && text_input_is_duplicate && `dupe`}
-        {@const can_create =
-          Boolean(allowUserOptions && createOptionMsg) && `create`}
+        {@const can_create = Boolean(allowUserOptions && createOptionMsg) && `create`}
         {@const no_match =
-          Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg) &&
-          `no-match`}
+        Boolean(navigable_options?.length === 0 && noMatchingOptionsMsg) &&
+        `no-match`}
         {@const msgType = is_dupe || can_create || no_match}
-        {@const msg =
-          msgType &&
-          {
-            dupe: duplicateOptionMsg,
-            create: createOptionMsg,
-            "no-match": noMatchingOptionsMsg,
-          }[msgType]}
+        {@const msg = msgType && {
+        dupe: duplicateOptionMsg,
+        create: createOptionMsg,
+        'no-match': noMatchingOptionsMsg,
+      }[msgType]}
         {@const can_add_user_option = msgType === `create` && allowUserOptions}
         {@const handle_create = (event: Event) =>
-          can_add_user_option && add(searchText as Option, event)}
+        can_add_user_option && add(searchText as Option, event)}
         {#if msg}
           <li
             onclick={handle_create}
-            onkeydown={can_add_user_option
-              ? if_enter_or_space(handle_create)
-              : undefined}
+            onkeydown={can_add_user_option ? if_enter_or_space(handle_create) : undefined}
             title={msgType === `create`
-              ? createOptionMsg
-              : msgType === `dupe`
-                ? duplicateOptionMsg
-                : ``}
+            ? createOptionMsg
+            : msgType === `dupe`
+            ? duplicateOptionMsg
+            : ``}
             class:active={option_msg_is_active}
             onmouseover={() => !ignore_hover && (option_msg_is_active = true)}
             onfocus={() => (option_msg_is_active = true)}
@@ -1694,7 +1653,7 @@
             style:cursor={{
               dupe: `not-allowed`,
               create: `pointer`,
-              "no-match": `default`,
+              'no-match': `default`,
             }[msgType]}
           >
             {#if userMsg}
@@ -1803,7 +1762,7 @@
     padding: var(--sms-selected-li-padding, 1pt 5pt);
     color: var(--sms-selected-text-color, var(--sms-text-color));
   }
-  :where(div.multiselect > ul.selected > li[draggable="true"]) {
+  :where(div.multiselect > ul.selected > li[draggable='true']) {
     cursor: grab;
   }
   :where(div.multiselect > ul.selected > li.active) {
@@ -1889,9 +1848,8 @@
     width: 100%;
     /* Default z-index if not portaled/overridden by portal */
     z-index: var(--sms-options-z-index, 3);
-
     overflow: auto;
-    transition: all 0.2s; /* Consider if this transition is desirable with portal positioning */
+    transition: all 0.2s; /* is this transition is desirable with portal positioning? */
     box-sizing: border-box;
     background: var(--sms-options-bg, light-dark(#fafafa, #1a1a1a));
     max-height: var(--sms-options-max-height, 50vh);
@@ -2029,11 +1987,8 @@
   }
   /* Indent grouped options for visual hierarchy */
   :where(
-      ul.options
-        > li:not(.group-header):not(.select-all):not(.user-msg):not(
-          .loading-more
-        )
-    ) {
+    ul.options > li:not(.group-header):not(.select-all):not(.user-msg):not(.loading-more)
+  ) {
     padding-left: var(
       --sms-group-item-padding-left,
       var(--sms-group-option-indent, 1.5ex)

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -4,7 +4,8 @@
   import { flip } from 'svelte/animate'
   import type { FocusEventHandler, KeyboardEventHandler } from 'svelte/elements'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
-  import { get_uuid, highlight_matches } from './attachments'
+  import { highlight_matches } from './attachments'
+  import { get_uuid } from './utils'
   import CircleSpinner from './CircleSpinner.svelte'
   import Icon from './Icon.svelte'
   import type { GroupedOptions, KeyboardShortcuts, MultiSelectProps } from './types'
@@ -167,18 +168,13 @@
     alt: boolean
     meta: boolean
   } {
-    const parts = shortcut
-      .toLowerCase()
-      .split(`+`)
-      .map((part) => part.trim())
+    const parts = shortcut.toLowerCase().split(`+`).map((part) => part.trim())
     const key = parts.pop() ?? ``
-    return {
-      key,
-      ctrl: parts.includes(`ctrl`),
-      shift: parts.includes(`shift`),
-      alt: parts.includes(`alt`),
-      meta: parts.includes(`meta`) || parts.includes(`cmd`),
-    }
+    const ctrl = parts.includes(`ctrl`)
+    const shift = parts.includes(`shift`)
+    const alt = parts.includes(`alt`)
+    const meta = parts.includes(`meta`) || parts.includes(`cmd`)
+    return { key, ctrl, shift, alt, meta }
   }
 
   function matches_shortcut(
@@ -194,13 +190,7 @@
     const shift_matches = event.shiftKey === parsed.shift
     const alt_matches = event.altKey === parsed.alt
     const meta_matches = event.metaKey === parsed.meta
-    return (
-      key_matches &&
-      ctrl_matches &&
-      shift_matches &&
-      alt_matches &&
-      meta_matches
-    )
+    return key_matches && ctrl_matches && shift_matches && alt_matches && meta_matches
   }
 
   // Default shortcuts
@@ -210,11 +200,7 @@
     open: null,
     close: null,
   }
-
-  const effective_shortcuts = $derived({
-    ...default_shortcuts,
-    ...shortcuts,
-  })
+  const effective_shortcuts = $derived({ ...default_shortcuts, ...shortcuts })
 
   // Extract loadOptions config into single derived object (supports both simple function and config object)
   const load_options_config = $derived.by(() => {

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -2,12 +2,9 @@
   import type { Page } from '@sveltejs/kit'
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
-  import {
-    click_outside,
-    get_uuid,
-    tooltip,
-    type TooltipOptions,
-  } from './attachments'
+  import type { TooltipOptions } from './attachments'
+  import { click_outside, tooltip } from './attachments'
+  import { get_uuid } from './utils'
   import Icon from './Icon.svelte'
   import type { NavRoute, NavRouteObject } from './types'
 
@@ -39,9 +36,7 @@
     ...rest
   }: {
     routes: NavRoute[]
-    children?: Snippet<
-      [{ is_open: boolean; panel_id: string; routes: NavRoute[] }]
-    >
+    children?: Snippet<[{ is_open: boolean; panel_id: string; routes: NavRoute[] }]>
     item?: Snippet<[ItemSnippetParams]>
     link?: Snippet<[{ href: string; label: string }]>
     menu_props?: HTMLAttributes<HTMLDivElement>
@@ -51,11 +46,9 @@
     tooltips?: Record<string, string | Omit<TooltipOptions, `disabled`>>
     tooltip_options?: Omit<TooltipOptions, `content`>
     breakpoint?: number
-    onnavigate?: (data: {
-      href: string
-      event: MouseEvent
-      route: NavRouteObject
-    }) => void | false
+    onnavigate?: (
+      data: { href: string; event: MouseEvent; route: NavRouteObject },
+    ) => void | false
     onopen?: () => void
     onclose?: () => void
   } & Omit<HTMLAttributes<HTMLElementTagNameMap[`nav`]>, `children`> = $props()

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
-  import type { Page } from "@sveltejs/kit";
-  import type { Snippet } from "svelte";
-  import type { HTMLAttributes } from "svelte/elements";
+  import type { Page } from '@sveltejs/kit'
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
   import {
     click_outside,
+    get_uuid,
     tooltip,
     type TooltipOptions,
-    get_uuid,
-  } from "./attachments";
-  import Icon from "./Icon.svelte";
-  import type { NavRoute, NavRouteObject } from "./types";
+  } from './attachments'
+  import Icon from './Icon.svelte'
+  import type { NavRoute, NavRouteObject } from './types'
 
   // Props for the item snippet's render_default function context
   interface ItemSnippetParams {
-    route: NavRouteObject; // normalized route object
-    href: string;
-    label: string;
-    is_active: boolean;
-    is_dropdown: boolean;
-    render_default: Snippet; // escape hatch to render default
+    route: NavRouteObject // normalized route object
+    href: string
+    label: string
+    is_active: boolean
+    is_dropdown: boolean
+    render_default: Snippet // escape hatch to render default
   }
 
   let {
@@ -38,73 +38,72 @@
     onclose,
     ...rest
   }: {
-    routes: NavRoute[];
+    routes: NavRoute[]
     children?: Snippet<
       [{ is_open: boolean; panel_id: string; routes: NavRoute[] }]
-    >;
-    item?: Snippet<[ItemSnippetParams]>;
-    link?: Snippet<[{ href: string; label: string }]>;
-    menu_props?: HTMLAttributes<HTMLDivElement>;
-    link_props?: HTMLAttributes<HTMLAnchorElement>;
-    page?: Page;
-    labels?: Record<string, string>;
-    tooltips?: Record<string, string | Omit<TooltipOptions, `disabled`>>;
-    tooltip_options?: Omit<TooltipOptions, `content`>;
-    breakpoint?: number;
+    >
+    item?: Snippet<[ItemSnippetParams]>
+    link?: Snippet<[{ href: string; label: string }]>
+    menu_props?: HTMLAttributes<HTMLDivElement>
+    link_props?: HTMLAttributes<HTMLAnchorElement>
+    page?: Page
+    labels?: Record<string, string>
+    tooltips?: Record<string, string | Omit<TooltipOptions, `disabled`>>
+    tooltip_options?: Omit<TooltipOptions, `content`>
+    breakpoint?: number
     onnavigate?: (data: {
-      href: string;
-      event: MouseEvent;
-      route: NavRouteObject;
-    }) => void | false;
-    onopen?: () => void;
-    onclose?: () => void;
-  } & Omit<HTMLAttributes<HTMLElementTagNameMap[`nav`]>, `children`> = $props();
+      href: string
+      event: MouseEvent
+      route: NavRouteObject
+    }) => void | false
+    onopen?: () => void
+    onclose?: () => void
+  } & Omit<HTMLAttributes<HTMLElementTagNameMap[`nav`]>, `children`> = $props()
 
-  let is_open = $state(false);
-  let hovered_dropdown = $state<string | null>(null);
-  let focused_item_index = $state<number>(-1);
-  let is_touch_device = $state(false);
-  let is_mobile = $state(false);
-  const panel_id = `nav-menu-${get_uuid()}`;
+  let is_open = $state(false)
+  let hovered_dropdown = $state<string | null>(null)
+  let focused_item_index = $state<number>(-1)
+  let is_touch_device = $state(false)
+  let is_mobile = $state(false)
+  const panel_id = `nav-menu-${get_uuid()}`
 
   // Track previous is_open state for callbacks
-  let prev_is_open = $state(false);
+  let prev_is_open = $state(false)
 
   // Detect touch device and handle responsive breakpoint
   $effect(() => {
-    if (typeof globalThis === `undefined`) return;
-    is_touch_device =
-      `ontouchstart` in globalThis || navigator.maxTouchPoints > 0;
+    if (typeof globalThis === `undefined`) return
+    is_touch_device = `ontouchstart` in globalThis || navigator.maxTouchPoints > 0
 
     // Handle responsive breakpoint via JS since CSS variables don't work in media queries
     const check_mobile = () => {
-      is_mobile = globalThis.innerWidth <= breakpoint;
-    };
-    check_mobile();
-    globalThis.addEventListener(`resize`, check_mobile);
-    return () => globalThis.removeEventListener(`resize`, check_mobile);
-  });
+      is_mobile = globalThis.innerWidth <= breakpoint
+    }
+    check_mobile()
+    globalThis.addEventListener(`resize`, check_mobile)
+    return () => globalThis.removeEventListener(`resize`, check_mobile)
+  })
 
   // Call onopen/onclose callbacks when menu state changes
   $effect(() => {
     if (is_open && !prev_is_open) {
-      onopen?.();
+      onopen?.()
     } else if (!is_open && prev_is_open) {
-      onclose?.();
+      onclose?.()
     }
-    prev_is_open = is_open;
-  });
+    prev_is_open = is_open
+  })
 
   function close_menus() {
-    is_open = false;
-    hovered_dropdown = null;
-    focused_item_index = -1;
+    is_open = false
+    hovered_dropdown = null
+    focused_item_index = -1
   }
 
   function toggle_dropdown(href: string, focus_first = false) {
-    const is_opening = hovered_dropdown !== href;
-    hovered_dropdown = hovered_dropdown === href ? null : href;
-    focused_item_index = is_opening && focus_first ? 0 : -1;
+    const is_opening = hovered_dropdown !== href
+    hovered_dropdown = hovered_dropdown === href ? null : href
+    focused_item_index = is_opening && focus_first ? 0 : -1
 
     // Focus management for keyboard users
     if (is_opening && focus_first) {
@@ -113,13 +112,13 @@
           .querySelector<HTMLElement>(
             `.dropdown[data-href="${href}"] [role="menuitem"]`,
           )
-          ?.focus();
-      }, 0);
+          ?.focus()
+      }, 0)
     }
   }
 
   function onkeydown(event: KeyboardEvent) {
-    if (event.key === `Escape`) close_menus();
+    if (event.key === `Escape`) close_menus()
   }
 
   function handle_dropdown_keydown(
@@ -127,12 +126,12 @@
     href: string,
     sub_routes: string[],
   ) {
-    const { key } = event;
+    const { key } = event
 
     if (key === `Enter` || key === ` `) {
-      event.preventDefault();
-      toggle_dropdown(href, true);
-      return;
+      event.preventDefault()
+      toggle_dropdown(href, true)
+      return
     }
 
     // Arrow key navigation within open dropdown
@@ -140,108 +139,108 @@
       hovered_dropdown === href &&
       (key === `ArrowDown` || key === `ArrowUp`)
     ) {
-      event.preventDefault();
-      const direction = key === `ArrowDown` ? 1 : -1;
+      event.preventDefault()
+      const direction = key === `ArrowDown` ? 1 : -1
       focused_item_index = Math.max(
         0,
         Math.min(sub_routes.length - 1, focused_item_index + direction),
-      );
+      )
       document
         .querySelectorAll<HTMLElement>(
           `.dropdown[data-href="${href}"] [role="menuitem"]`,
         )
-        ?.[focused_item_index]?.focus();
+        ?.[focused_item_index]?.focus()
     }
 
     // Open dropdown with ArrowDown when closed
     if (hovered_dropdown !== href && key === `ArrowDown`) {
-      event.preventDefault();
-      toggle_dropdown(href, true);
+      event.preventDefault()
+      toggle_dropdown(href, true)
     }
   }
 
   function handle_dropdown_item_keydown(event: KeyboardEvent, href: string) {
     if (event.key === `Escape`) {
-      event.preventDefault();
-      close_menus();
+      event.preventDefault()
+      close_menus()
       document
         .querySelector<HTMLButtonElement>(
           `.dropdown[data-href="${href}"] [data-dropdown-toggle]`,
         )
-        ?.focus();
+        ?.focus()
     }
   }
 
   function is_current(path: string | undefined) {
-    if (!path) return undefined;
-    if (path === `/`) return page?.url.pathname === `/` ? `page` : undefined;
+    if (!path) return undefined
+    if (path === `/`) return page?.url.pathname === `/` ? `page` : undefined
     // Match exact path or path followed by / to avoid partial matches
     // e.g. /tc-periodic-v2 should not match /tc-periodic
-    const pathname = page?.url.pathname;
-    const exact_match = pathname === path;
-    const prefix_match = pathname?.startsWith(path + `/`);
-    return exact_match || prefix_match ? `page` : undefined;
+    const pathname = page?.url.pathname
+    const exact_match = pathname === path
+    const prefix_match = pathname?.startsWith(path + `/`)
+    return exact_match || prefix_match ? `page` : undefined
   }
 
   const is_child_current = (sub_routes: string[]) =>
-    sub_routes.some((child_path) => is_current(child_path) === `page`);
+    sub_routes.some((child_path) => is_current(child_path) === `page`)
 
   function format_label(text: string | undefined, remove_parent = false) {
-    if (!text) return { label: ``, style: `` };
-    const custom_label = labels?.[text];
-    if (custom_label) return { label: custom_label, style: `` };
+    if (!text) return { label: ``, style: `` }
+    const custom_label = labels?.[text]
+    if (custom_label) return { label: custom_label, style: `` }
 
-    if (remove_parent) text = text.split(`/`).filter(Boolean).pop() ?? text;
-    let label = text.replace(/^\//, ``).replaceAll(`-`, ` `);
+    if (remove_parent) text = text.split(`/`).filter(Boolean).pop() ?? text
+    let label = text.replace(/^\//, ``).replaceAll(`-`, ` `)
     // Handle root path '/' which becomes empty after stripping
-    if (!label && text === `/`) label = `Home`;
-    return { label, style: label ? `text-transform: capitalize` : `` };
+    if (!label && text === `/`) label = `Home`
+    return { label, style: label ? `text-transform: capitalize` : `` }
   }
 
   // Normalize all route formats to NavRouteObject
   function parse_route(route: NavRoute): NavRouteObject {
-    if (typeof route === `string`) return { href: route };
+    if (typeof route === `string`) return { href: route }
     if (Array.isArray(route)) {
-      const [href, second] = route;
+      const [href, second] = route
       return Array.isArray(second)
         ? { href, children: second }
-        : { href, label: second };
+        : { href, label: second }
     }
-    return route;
+    return route
   }
 
   function get_tooltip(route: NavRouteObject) {
     // Priority: disabled message > route.tooltip > tooltips[href]
     if (typeof route.disabled === `string`) {
-      return tooltip({ ...tooltip_options, content: route.disabled });
+      return tooltip({ ...tooltip_options, content: route.disabled })
     }
-    const content = route.tooltip ?? tooltips?.[route.href];
-    if (!content) return undefined;
+    const content = route.tooltip ?? tooltips?.[route.href]
+    if (!content) return undefined
     // Support both string (content only) and object (full options) formats
-    const opts = typeof content === `string` ? { content } : content;
-    return tooltip({ ...tooltip_options, ...opts });
+    const opts = typeof content === `string` ? { content } : content
+    return tooltip({ ...tooltip_options, ...opts })
   }
 
   // Handle link click with onnavigate callback
   function handle_link_click(event: MouseEvent, route: NavRouteObject) {
     if (route.disabled) {
-      event.preventDefault();
-      return;
+      event.preventDefault()
+      return
     }
     if (onnavigate) {
-      const result = onnavigate({ href: route.href, event, route });
+      const result = onnavigate({ href: route.href, event, route })
       if (result === false) {
-        event.preventDefault();
-        return;
+        event.preventDefault()
+        return
       }
     }
-    close_menus();
+    close_menus()
   }
 
   // Get external link attributes
   function get_external_attrs(route: NavRouteObject) {
-    if (!route.external) return {};
-    return { target: `_blank`, rel: `noopener noreferrer` };
+    if (!route.external) return {}
+    return { target: `_blank`, rel: `noopener noreferrer` }
   }
 </script>
 
@@ -259,8 +258,8 @@
       class="disabled {parsed_route.class ?? ``}"
       style={`${formatted.style}; ${parsed_route.style ?? ``}`}
       aria-disabled="true"
-      {@attach item_tooltip}>{@html formatted.label}</span
-    >
+      {@attach item_tooltip}
+    >{@html formatted.label}</span>
   {:else if link}
     {@render link({ href: parsed_route.href, label: formatted.label })}
   {:else}
@@ -306,7 +305,17 @@
     {onkeydown}
     {...menu_props}
   >
-    {#each routes as route, route_idx (`${route_idx}-${typeof route === `string` ? route : Array.isArray(route) ? route[0] : (route.href ?? `sep-${route_idx}`)}`)}
+    {#each routes as
+      route,
+      route_idx
+      (`${route_idx}-${
+        typeof route === `string`
+          ? route
+          : Array.isArray(route)
+          ? route[0]
+          : (route.href ?? `sep-${route_idx}`)
+      }`)
+    }
       {@const parsed_route = parse_route(route)}
       {@const formatted = format_label(parsed_route.label ?? parsed_route.href)}
       {@const sub_routes = parsed_route.children}
@@ -323,8 +332,8 @@
         {@const child_is_active = is_child_current(sub_routes)}
         {@const parent_page_exists = sub_routes.includes(parsed_route.href)}
         {@const filtered_sub_routes = sub_routes.filter(
-          (r) => r !== parsed_route.href,
-        )}
+        (r) => r !== parsed_route.href,
+      )}
         <div
           class="dropdown"
           class:active={child_is_active}
@@ -332,14 +341,13 @@
           data-href={parsed_route.href}
           role="group"
           aria-current={child_is_active ? `true` : undefined}
-          onmouseenter={() =>
-            !is_touch_device && (hovered_dropdown = parsed_route.href)}
+          onmouseenter={() => !is_touch_device && (hovered_dropdown = parsed_route.href)}
           onmouseleave={() => !is_touch_device && (hovered_dropdown = null)}
           onfocusin={() => (hovered_dropdown = parsed_route.href)}
           onfocusout={(event) => {
-            const next = event.relatedTarget as Node | null;
+            const next = event.relatedTarget as Node | null
             if (!next || !(event.currentTarget as HTMLElement).contains(next)) {
-              hovered_dropdown = null;
+              hovered_dropdown = null
             }
           }}
         >
@@ -349,8 +357,8 @@
                 class="disabled {parsed_route.class ?? ``}"
                 style={`${formatted.style}; ${parsed_route.style ?? ``}`}
                 aria-disabled="true"
-                {@attach item_tooltip}>{@html formatted.label}</span
-              >
+                {@attach item_tooltip}
+              >{@html formatted.label}</span>
             {:else if parent_page_exists}
               <a
                 href={parsed_route.href}
@@ -367,8 +375,8 @@
               <span
                 class={parsed_route.class}
                 style={`${formatted.style}; ${parsed_route.style ?? ``}`}
-                {@attach item_tooltip}>{@html formatted.label}</span
-              >
+                {@attach item_tooltip}
+              >{@html formatted.label}</span>
             {/if}
             <button
               type="button"
@@ -378,11 +386,11 @@
               aria-haspopup="true"
               onclick={() => toggle_dropdown(parsed_route.href, false)}
               onkeydown={(event) =>
-                handle_dropdown_keydown(
-                  event,
-                  parsed_route.href,
-                  filtered_sub_routes,
-                )}
+              handle_dropdown_keydown(
+                event,
+                parsed_route.href,
+                filtered_sub_routes,
+              )}
             >
               <Icon icon="ChevronExpand" style="width: 0.8em; height: 0.8em" />
             </button>
@@ -391,17 +399,16 @@
             class:visible={hovered_dropdown === parsed_route.href}
             role="menu"
             tabindex="-1"
-            onmouseenter={() =>
-              !is_touch_device && (hovered_dropdown = parsed_route.href)}
+            onmouseenter={() => !is_touch_device && (hovered_dropdown = parsed_route.href)}
             onmouseleave={() => !is_touch_device && (hovered_dropdown = null)}
             onfocusin={() => (hovered_dropdown = parsed_route.href)}
             onfocusout={(event) => {
-              const next = event.relatedTarget as Node | null;
+              const next = event.relatedTarget as Node | null
               if (
                 !next ||
                 !(event.currentTarget as HTMLElement).contains(next)
               ) {
-                hovered_dropdown = null;
+                hovered_dropdown = null
               }
             }}
           >
@@ -409,19 +416,14 @@
               {@const child_formatted = format_label(child_href, true)}
               {@const child_tooltip = get_tooltip({ href: child_href })}
               {#if link}
-                {@render link({
-                  href: child_href,
-                  label: child_formatted.label,
-                })}
+                {@render link({ href: child_href, label: child_formatted.label })}
               {:else}
                 <a
                   href={child_href}
                   role="menuitem"
                   aria-current={is_current(child_href)}
-                  onclick={(event) =>
-                    handle_link_click(event, { href: child_href })}
-                  onkeydown={(event) =>
-                    handle_dropdown_item_keydown(event, parsed_route.href)}
+                  onclick={(event) => handle_link_click(event, { href: child_href })}
+                  onkeydown={(event) => handle_dropdown_item_keydown(event, parsed_route.href)}
                   {...link_props}
                   style={`${child_formatted.style}; ${link_props?.style ?? ``}`}
                   {@attach child_tooltip}
@@ -445,13 +447,13 @@
           {/snippet}
           <span class:align-right={is_right}>
             {@render item({
-              route: parsed_route,
-              href: parsed_route.href,
-              label: formatted.label,
-              is_active,
-              is_dropdown,
-              render_default: render_default_snippet,
-            })}
+          route: parsed_route,
+          href: parsed_route.href,
+          label: formatted.label,
+          is_active,
+          is_dropdown,
+          render_default: render_default_snippet,
+        })}
           </span>
         {:else}
           <span class:align-right={is_right}>
@@ -504,7 +506,7 @@
   .menu > span > a:hover {
     background-color: var(--nav-link-bg-hover);
   }
-  .menu > span > a[aria-current="page"] {
+  .menu > span > a[aria-current='page'] {
     color: var(--nav-link-active-color);
   }
   /* Disabled items */
@@ -541,7 +543,7 @@
     color: var(--nav-link-active-color);
   }
   .dropdown::after {
-    content: "";
+    content: '';
     position: absolute;
     top: 100%;
     left: 0;
@@ -566,7 +568,7 @@
     color: inherit;
     border-radius: var(--nav-border-radius) 0 0 var(--nav-border-radius);
   }
-  .dropdown > div:first-child > a[aria-current="page"] {
+  .dropdown > div:first-child > a[aria-current='page'] {
     color: var(--nav-link-active-color);
   }
   .dropdown > div:first-child > button {
@@ -592,8 +594,7 @@
     margin: var(--nav-dropdown-margin, 3pt 0 0 0);
     min-width: max-content;
     background-color: var(--nav-dropdown-bg, var(--nav-surface-bg));
-    border: 1px solid
-      var(--nav-dropdown-border-color, var(--nav-surface-border));
+    border: 1px solid var(--nav-dropdown-border-color, var(--nav-surface-border));
     border-radius: var(--nav-border-radius, 6pt);
     box-shadow: var(--nav-dropdown-shadow, var(--nav-surface-shadow));
     padding: var(--nav-dropdown-padding, 2pt 3pt);
@@ -616,7 +617,7 @@
   .dropdown > div:last-child a:hover {
     background-color: var(--nav-link-bg-hover);
   }
-  .dropdown > div:last-child a[aria-current="page"] {
+  .dropdown > div:last-child a[aria-current='page'] {
     color: var(--nav-link-active-color);
   }
   /* Mobile burger button */
@@ -641,13 +642,13 @@
     transition: all 0.2s linear;
     transform-origin: center;
   }
-  .burger[aria-expanded="true"] span:first-child {
+  .burger[aria-expanded='true'] span:first-child {
     transform: translateY(0.4rem) rotate(45deg);
   }
-  .burger[aria-expanded="true"] span:nth-child(2) {
+  .burger[aria-expanded='true'] span:nth-child(2) {
     opacity: 0;
   }
-  .burger[aria-expanded="true"] span:nth-child(3) {
+  .burger[aria-expanded='true'] span:nth-child(3) {
     transform: translateY(-0.4rem) rotate(-45deg);
   }
   /* Mobile styles - using .mobile class set via JS based on breakpoint prop */

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -28,8 +28,10 @@ export function get_uuid(): string {
   buf[6] = (buf[6] & 0x0f) | 0x40
   buf[8] = (buf[8] & 0x3f) | 0x80
 
-  const hex = [...buf].map((b) => b.toString(16).padStart(2, '0')).join('')
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+  const hex = [...buf].map((b) => b.toString(16).padStart(2, `0`)).join(``)
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${
+    hex.slice(16, 20)
+  }-${hex.slice(20)}`
 }
 
 export interface DraggableOptions {
@@ -260,8 +262,8 @@ export const resizable =
       node.style.cursor = edge === `right` || edge === `left`
         ? `ew-resize`
         : edge === `top` || edge === `bottom`
-          ? `ns-resize`
-          : ``
+        ? `ns-resize`
+        : ``
     }
 
     node.addEventListener(`mousedown`, on_mousedown)
@@ -345,8 +347,9 @@ export const sortable = (options: SortableOptions = {}) => (node: HTMLElement) =
       }
       header.classList.add(sort_dir > 0 ? asc_class : desc_class)
       Object.assign(header.style, sorted_style)
-      header.textContent = `${header.textContent?.replace(/ ↑| ↓/, ``)} ${sort_dir > 0 ? `↑` : `↓`
-        }`
+      header.textContent = `${header.textContent?.replace(/ ↑| ↓/, ``)} ${
+        sort_dir > 0 ? `↑` : `↓`
+      }`
 
       const table_body = node.querySelector(`tbody`)
       if (!table_body) return
@@ -634,21 +637,21 @@ export const tooltip = (options: TooltipOptions = {}): Attachment => (node: Elem
 
         // Mirror CSS custom properties from the trigger node onto the tooltip element
         const trigger_styles = getComputedStyle(element)
-          ;[
-            `--tooltip-bg`,
-            `--text-color`,
-            `--tooltip-border`,
-            `--tooltip-padding`,
-            `--tooltip-radius`,
-            `--tooltip-font-size`,
-            `--tooltip-shadow`,
-            `--tooltip-max-width`,
-            `--tooltip-opacity`,
-            `--tooltip-arrow-size`,
-          ].forEach((name) => {
-            const value = trigger_styles.getPropertyValue(name).trim()
-            if (value) tooltip_el.style.setProperty(name, value)
-          })
+        ;[
+          `--tooltip-bg`,
+          `--text-color`,
+          `--tooltip-border`,
+          `--tooltip-padding`,
+          `--tooltip-radius`,
+          `--tooltip-font-size`,
+          `--tooltip-shadow`,
+          `--tooltip-max-width`,
+          `--tooltip-opacity`,
+          `--tooltip-arrow-size`,
+        ].forEach((name) => {
+          const value = trigger_styles.getPropertyValue(name).trim()
+          if (value) tooltip_el.style.setProperty(name, value)
+        })
 
         // Append early so we can read computed border styles for arrow border
         document.body.appendChild(tooltip_el)

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,4 +1,8 @@
 import { type Attachment } from 'svelte/attachments'
+import { get_uuid } from './utils'
+
+// Re-export get_uuid for backwards compatibility
+export { get_uuid }
 
 // Type definitions for CSS highlight API (experimental)
 declare global {
@@ -10,28 +14,6 @@ declare global {
     delete(key: string): boolean
     set(key: string, value: Highlight): this
   }
-}
-
-// Helper: Generates a cryptographically secure RFC 4122 v4 UUID
-// Checks for secure context first, then falls back to getRandomValues
-export function get_uuid(): string {
-  if (globalThis.isSecureContext && globalThis.crypto?.randomUUID) {
-    return globalThis.crypto.randomUUID()
-  }
-
-  // Fallback: RFC 4122 v4 via crypto.getRandomValues
-  // Supported in all modern browsers even in non-secure contexts (http)
-  const buf = new Uint8Array(16)
-  globalThis.crypto.getRandomValues(buf)
-
-  // Set version (4) and variant (RFC 4122) bits
-  buf[6] = (buf[6] & 0x0f) | 0x40
-  buf[8] = (buf[8] & 0x3f) | 0x80
-
-  const hex = [...buf].map((b) => b.toString(16).padStart(2, `0`)).join(``)
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${
-    hex.slice(16, 20)
-  }-${hex.slice(20)}`
 }
 
 export interface DraggableOptions {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,23 @@
 import type { Option } from './types'
 
+// Generates a cryptographically secure RFC 4122 v4 UUID
+// Uses native randomUUID in secure contexts, falls back to getRandomValues for HTTP
+export function get_uuid(): string {
+  if (globalThis.isSecureContext && globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID()
+  }
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error(`crypto.getRandomValues not available`)
+  }
+  const buf = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(buf)
+  // Set version (4) and variant (RFC 4122) bits
+  buf[6] = (buf[6] & 0x0f) | 0x40
+  buf[8] = (buf[8] & 0x3f) | 0x80
+  const hex = [...buf].map((b) => b.toString(16).padStart(2, `0`)).join(``)
+  return hex.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, `$1-$2-$3-$4-$5`)
+}
+
 // Type guard for checking if a value is a non-null object
 export const is_object = (val: unknown): val is Record<string, unknown> =>
   typeof val === `object` && val !== null

--- a/tests/vitest/FileDetails.svelte.test.ts
+++ b/tests/vitest/FileDetails.svelte.test.ts
@@ -3,36 +3,21 @@ import { flushSync, mount, tick } from 'svelte'
 import { expect, test } from 'vitest'
 import { doc_query } from './index'
 
-test(`FileDetails renders all files passed`, () => {
+test(`FileDetails renders files in ordered list with titles and contents`, () => {
   const files = [
     { title: `file1`, content: `content1` },
     { title: `file2`, content: `content2` },
   ]
   mount(FileDetails, { target: document.body, props: { files } })
 
-  const details = document.querySelectorAll(`li > details`)
-  expect(details.length).toBe(2)
+  // Check structure: ordered list with details elements
+  expect(doc_query(`ol`).children.length).toBe(2)
+  expect(document.querySelectorAll(`li > details`).length).toBe(2)
+  expect(document.querySelectorAll(`summary`).length).toBe(2)
 
-  // check items are wrapped in ordered list
-  const ol = doc_query(`ol`)
-  expect(ol.children.length).toBe(2)
-})
-
-test(`FileDetails renders file titles and contents`, () => {
-  const files = [
-    { title: `file1`, content: `content1` },
-    { title: `file2`, content: `content2` },
-  ]
-  mount(FileDetails, { target: document.body, props: { files } })
-
-  const titles = document.querySelectorAll(`summary`)
-  expect(titles.length).toBe(2)
-
-  const contents = Array.from(document.querySelectorAll(`pre > code`))
-
-  for (const [idx, src] of contents.entries()) {
-    expect(src.textContent).toBe(files[idx].content)
-  }
+  // Check contents
+  const contents = document.querySelectorAll(`pre > code`)
+  files.forEach((file, idx) => expect(contents[idx].textContent).toBe(file.content))
 })
 
 test(`toggle all button opens, closes, and handles partial open state`, async () => {

--- a/tests/vitest/GitHubCorner.test.ts
+++ b/tests/vitest/GitHubCorner.test.ts
@@ -1,25 +1,11 @@
 import { GitHubCorner } from '$lib'
 import { mount } from 'svelte'
-import { describe, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
-describe(`GitHubCorner`, () => {
-  test(`renders with default props`, () => {
-    mount(GitHubCorner, {
-      target: document.body,
-      props: { href: `https://github.com/janosh/blog` },
-    })
-    const link = document.querySelector(`a`)
-    expect(link).toBeTruthy()
-    expect(link?.getAttribute(`href`)).toBe(`https://github.com/janosh/blog`)
-  })
-
-  test(`renders GitHub corner component`, () => {
-    mount(GitHubCorner, {
-      target: document.body,
-      props: { href: `https://github.com/test/repo` },
-    })
-    const link = document.querySelector(`a`)
-    expect(link).toBeTruthy()
-    expect(link?.querySelector(`svg`)).toBeTruthy()
-  })
+test(`GitHubCorner renders link with svg`, () => {
+  const href = `https://github.com/foo/bar`
+  mount(GitHubCorner, { target: document.body, props: { href } })
+  const link = document.querySelector(`a`)
+  expect(link?.getAttribute(`href`)).toBe(href)
+  expect(link?.querySelector(`svg`)).toBeTruthy()
 })

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -1,6 +1,31 @@
 import type { Option, OptionStyle } from '$lib'
-import { fuzzy_match, get_label, get_style, has_group, is_object } from '$lib/utils'
+import {
+  fuzzy_match,
+  get_label,
+  get_style,
+  get_uuid,
+  has_group,
+  is_object,
+} from '$lib/utils'
 import { describe, expect, test, vi } from 'vitest'
+
+describe(`get_uuid`, () => {
+  // RFC 4122 v4: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx (y = 8/9/a/b)
+  const uuid_regex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+  test(`returns valid RFC 4122 v4 UUIDs`, () => {
+    // Regex validates: length, hyphens, version (4), variant (8/9/a/b)
+    for (let idx = 0; idx < 20; idx++) {
+      expect(get_uuid()).toMatch(uuid_regex)
+    }
+  })
+
+  test(`generates unique UUIDs`, () => {
+    const uuids = new Set(Array.from({ length: 100 }, () => get_uuid()))
+    expect(uuids.size).toBe(100)
+  })
+})
 
 describe(`get_label`, () => {
   test.each([


### PR DESCRIPTION
Closes #385

- Add reliable UUID generation with a fallback for environments where `crypto.randomUUID` is unavailable, including tooltip and panel IDs
- Export UUID generation from the public utilities API