### PR TITLE
fix: use value field for key function to prevent case-variant crashes

### DIFF
--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -26,7 +26,7 @@
     duplicateOptionMsg = `This option is already selected`,
     duplicates = false,
     keepSelectedInDropdown = false,
-    key = (opt) => `${utils.get_value(opt)}`,
+    key = (opt) => utils.get_option_key(opt),
     filterFunc = (opt, searchText) => {
       if (!searchText) return true
       const label = `${utils.get_label(opt)}`
@@ -407,14 +407,6 @@
   let effective_options = $derived(
     loadOptions ? loaded_options : (options ?? []),
   )
-
-  // Warn developers about case-variant labels in dev mode (runs once per options change)
-  let warned_case_variants = false
-  $effect(() => {
-    if (!warned_case_variants && effective_options.length > 0) {
-      warned_case_variants = utils.warn_case_variants(effective_options)
-    }
-  })
 
   // Cache selected keys and labels to avoid repeated .map() calls
   let selected_keys = $derived(selected.map(key))

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -26,7 +26,7 @@
     duplicateOptionMsg = `This option is already selected`,
     duplicates = false,
     keepSelectedInDropdown = false,
-    key = (opt) => `${utils.get_label(opt)}`.toLowerCase(),
+    key = (opt) => `${utils.get_value(opt)}`,
     filterFunc = (opt, searchText) => {
       if (!searchText) return true
       const label = `${utils.get_label(opt)}`
@@ -407,6 +407,14 @@
   let effective_options = $derived(
     loadOptions ? loaded_options : (options ?? []),
   )
+
+  // Warn developers about case-variant labels in dev mode (runs once per options change)
+  let warned_case_variants = false
+  $effect(() => {
+    if (!warned_case_variants && effective_options.length > 0) {
+      warned_case_variants = utils.warn_case_variants(effective_options)
+    }
+  })
 
   // Cache selected keys and labels to avoid repeated .map() calls
   let selected_keys = $derived(selected.map(key))

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -719,7 +719,9 @@
       option_to_add = Number(option_to_add) as Option // convert to number if possible
     }
 
-    const is_duplicate = selected_keys_set.has(key(option_to_add))
+    // Check for duplicates by key OR by label (for user-typed text matching selected labels)
+    const is_duplicate = selected_keys_set.has(key(option_to_add)) ||
+      selected_labels_set.has(`${utils.get_label(option_to_add)}`)
     const max_reached = maxSelect !== null && maxSelect !== 1 &&
       selected.length >= maxSelect
     // Fire events for blocked add attempts

--- a/src/lib/MultiSelect.svelte
+++ b/src/lib/MultiSelect.svelte
@@ -413,7 +413,8 @@
   let selected_labels = $derived(selected.map(utils.get_label))
   // Sets for O(1) lookups (used in template, has_user_msg, group_header_state, batch operations)
   let selected_keys_set = $derived(new Set(selected_keys))
-  let selected_labels_set = $derived(new Set(selected_labels))
+  // String-normalized for consistent comparison (numeric labels like 123 match "123")
+  let selected_labels_set = $derived(new Set(selected_labels.map((lbl) => `${lbl}`)))
   // Lowercase labels set for case-insensitive duplicate detection
   let selected_labels_lower_set = $derived(
     duplicates === `case-insensitive`
@@ -421,9 +422,9 @@
       : null,
   )
   // Helper to check if a label is already selected (respects case-insensitive mode)
-  const is_label_selected = (label: string) =>
+  const is_label_selected = (label: string): boolean =>
     duplicates === `case-insensitive`
-      ? selected_labels_lower_set?.has(label.toLowerCase())
+      ? selected_labels_lower_set?.has(label.toLowerCase()) ?? false
       : selected_labels_set.has(label)
 
   // Memoized Set of disabled option keys for O(1) lookups in large option sets
@@ -1112,7 +1113,7 @@
   }
 
   // O(1) lookup using pre-computed Set instead of O(n) array.includes()
-  const is_selected = (label: string | number) => selected_labels_set.has(label)
+  const is_selected = (label: string | number) => selected_labels_set.has(`${label}`)
 
   const if_enter_or_space =
     (handler: (event: KeyboardEvent) => void) => (event: KeyboardEvent) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -149,7 +149,9 @@ export interface MultiSelectProps<T extends Option = Option>
   // 'plain' (left border and background color to differentiate selected options),
   // 'checkboxes' (each option is prefixed by a checkbox).
   keepSelectedInDropdown?: false | `plain` | `checkboxes`
-  // case-insensitive equality comparison after string coercion and looks only at the `label` key of object options by default
+  // Function to generate unique keys for options. By default, uses the `value` field for object options
+  // (falling back to `label` if `value` is undefined), or the option itself for primitives.
+  // This ensures options with unique `value` fields (e.g., UUIDs) are treated as distinct even if labels match.
   key?: (opt: T) => unknown
   filterFunc?: (opt: T, searchText: string) => boolean
   fuzzy?: boolean // whether to use fuzzy matching (default: true) or substring matching (false)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -144,15 +144,14 @@ export interface MultiSelectProps<T extends Option = Option>
   disabled?: boolean
   disabledInputTitle?: string
   duplicateOptionMsg?: string
-  duplicates?: boolean // whether to allow duplicate options
+  // Controls duplicate detection: false (default, case-sensitive), true (allow all), 'case-insensitive' (block case variants)
+  duplicates?: boolean | `case-insensitive`
   // keepSelectedInDropdown controls whether selected options remain in dropdown: false (default),
   // 'plain' (left border and background color to differentiate selected options),
   // 'checkboxes' (each option is prefixed by a checkbox).
   keepSelectedInDropdown?: false | `plain` | `checkboxes`
-  // Function to generate unique keys for options. By default, combines label + value for object options
-  // (e.g., "foo-uuid-123" or "foo-" if no value), or uses the primitive as string for string/number options.
-  // This ensures uniqueness even when options have case-variant labels or the same value field.
-  // Note: duplicate detection also checks labels, so typing "Apple" when any "Apple" is selected is blocked.
+  // Function to generate unique keys for options. Default: value ?? label for objects, primitive for strings/numbers.
+  // Duplicate detection also checks labels, so typing "Apple" when any "Apple" is selected is blocked (unless duplicates=true).
   key?: (opt: T) => unknown
   filterFunc?: (opt: T, searchText: string) => boolean
   fuzzy?: boolean // whether to use fuzzy matching (default: true) or substring matching (false)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -149,9 +149,10 @@ export interface MultiSelectProps<T extends Option = Option>
   // 'plain' (left border and background color to differentiate selected options),
   // 'checkboxes' (each option is prefixed by a checkbox).
   keepSelectedInDropdown?: false | `plain` | `checkboxes`
-  // Function to generate unique keys for options. By default, uses the `value` field for object options
-  // (falling back to `label` if `value` is undefined), or the option itself for primitives.
-  // This ensures options with unique `value` fields (e.g., UUIDs) are treated as distinct even if labels match.
+  // Function to generate unique keys for options. By default, combines label + value for object options
+  // (e.g., "foo-uuid-123" or "foo-" if no value), or uses the primitive as string for string/number options.
+  // This ensures uniqueness even when options have case-variant labels or the same value field.
+  // Note: duplicate detection also checks labels, so typing "Apple" when any "Apple" is selected is blocked.
   key?: (opt: T) => unknown
   filterFunc?: (opt: T, searchText: string) => boolean
   fuzzy?: boolean // whether to use fuzzy matching (default: true) or substring matching (false)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,46 +33,11 @@ export const get_label = (opt: Option) => {
   return `${opt}`
 }
 
-// Get the value from an option object, falling back to label if value is undefined
-// For primitive options (string/number), returns the option itself
-export const get_value = (opt: Option): unknown => {
-  if (is_object(opt)) {
-    // Use value if defined, otherwise fall back to label
-    return opt.value !== undefined ? opt.value : opt.label
-  }
-  return opt
-}
-
-// Check for case-variant labels and warn developers
-// Returns true if case variants were found
-export const warn_case_variants = (options: Option[]): boolean => {
-  const labels = options.map((o) => `${get_label(o)}`)
-  const lowerLabels = labels.map((l) => l.toLowerCase())
-  const seen = new Map<string, string[]>()
-
-  labels.forEach((label, i) => {
-    const lower = lowerLabels[i]
-    const existing = seen.get(lower)
-    if (existing) {
-      existing.push(label)
-    } else {
-      seen.set(lower, [label])
-    }
-  })
-
-  const variants = [...seen.entries()]
-    .filter(([, labelList]) => labelList.length > 1 && new Set(labelList).size > 1)
-    .map(([, labelList]) => [...new Set(labelList)].join(`, `))
-
-  if (variants.length > 0) {
-    console.warn(
-      `[svelte-multiselect] Options contain labels that differ only by case: [${variants.join(`] [`)}]. ` +
-      `Each will be treated as a distinct option. If this is unintended, filter your options or provide a custom key function.`
-    )
-    return true
-  }
-  return false
-}
+// Generate a unique key for an option by combining label and value
+// For object options: "label-value" (e.g., "foo-uuid-123" or "foo-" if no value)
+// For primitives: the primitive as string
+export const get_option_key = (opt: Option): string =>
+  is_object(opt) ? `${get_label(opt)}-${opt.value ?? ``}` : `${get_label(opt)}`
 
 // This function is used extract CSS strings from a {selected, option} style
 // object to be used in the style attribute of the option.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,11 +33,11 @@ export const get_label = (opt: Option) => {
   return `${opt}`
 }
 
-// Generate a unique key for an option by combining label and value
-// For object options: "label-value" (e.g., "foo-uuid-123" or "foo-" if no value)
-// For primitives: the primitive as string
-export const get_option_key = (opt: Option): string =>
-  is_object(opt) ? `${get_label(opt)}-${opt.value ?? ``}` : `${get_label(opt)}`
+// Generate a unique key for an option, preserving value identity
+// For object options: uses value if defined, otherwise label (no case normalization)
+// For primitives: the primitive itself
+export const get_option_key = (opt: Option): unknown =>
+  is_object(opt) ? opt.value ?? get_label(opt) : opt
 
 // This function is used extract CSS strings from a {selected, option} style
 // object to be used in the style attribute of the option.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,10 +52,12 @@ export const warn_case_variants = (options: Option[]): boolean => {
 
   labels.forEach((label, i) => {
     const lower = lowerLabels[i]
-    if (!seen.has(lower)) {
-      seen.set(lower, [])
+    const existing = seen.get(lower)
+    if (existing) {
+      existing.push(label)
+    } else {
+      seen.set(lower, [label])
     }
-    seen.get(lower)!.push(label)
   })
 
   const variants = [...seen.entries()]

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -2,6 +2,7 @@ import type { Option, OptionStyle } from '$lib'
 import {
   fuzzy_match,
   get_label,
+  get_option_key,
   get_style,
   get_uuid,
   has_group,
@@ -200,5 +201,42 @@ describe(`has_group`, () => {
     [42, false],
   ])(`has_group(%j) returns %s`, (input, expected) => {
     expect(has_group(input as Option)).toBe(expected)
+  })
+})
+
+describe(`get_option_key`, () => {
+  test.each([
+    // Object options - combines label + value
+    [{ label: `Apple`, value: 1 }, `Apple-1`],
+    [{ label: `Apple`, value: `uuid-123` }, `Apple-uuid-123`],
+    [{ label: `pd`, value: `uuid-1` }, `pd-uuid-1`],
+    [{ label: `PD`, value: `uuid-2` }, `PD-uuid-2`], // case preserved
+    // Object options without value - label + empty string
+    [{ label: `Apple` }, `Apple-`],
+    [{ label: `Apple`, value: undefined }, `Apple-`],
+    [{ label: `Apple`, value: null }, `Apple-`],
+    // Object options with falsy but defined values
+    [{ label: `Apple`, value: 0 }, `Apple-0`],
+    [{ label: `Apple`, value: `` }, `Apple-`],
+    [{ label: `Apple`, value: false }, `Apple-false`],
+    // Primitive options - just the label
+    [`apple`, `apple`],
+    [`Apple`, `Apple`], // case preserved
+    [123, `123`],
+    [0, `0`],
+  ])(`get_option_key(%j) returns %j`, (input, expected) => {
+    expect(get_option_key(input as Option)).toBe(expected)
+  })
+
+  test(`case-variant labels produce unique keys`, () => {
+    const options = [
+      { label: `pd`, value: `uuid-1` },
+      { label: `PD`, value: `uuid-2` },
+      { label: `Pd`, value: `uuid-3` },
+    ]
+    const keys = options.map(get_option_key)
+    expect(keys).toEqual([`pd-uuid-1`, `PD-uuid-2`, `Pd-uuid-3`])
+    // All keys should be unique
+    expect(new Set(keys).size).toBe(3)
   })
 })


### PR DESCRIPTION
Fixes #391

The default key function was using `label.toLowerCase()` which caused duplicate key errors when options had labels differing only by case (e.g., "pd" and "PD"). This crashed the component on mount even when unique `value` fields (UUIDs) were provided.

## Changes

### 1. Updated default key function (`MultiSelect.svelte`)

```javascript
// Before (crashes with case variants):
key = (opt) => `${utils.get_label(opt)}`.toLowerCase()

// After (uses unique identifier when available):
key = (opt) => `${utils.get_value(opt)}`
```

### 2. Added `get_value()` helper (`utils.ts`)

Returns the `value` field for object options (falling back to `label` if undefined), or the option itself for primitives.

### 3. Added `warn_case_variants()` helper (`utils.ts`)

Logs a console warning when case-variant labels are detected:

```
[svelte-multiselect] Options contain labels that differ only by case: [pd, PD, Pd].
Each will be treated as a distinct option. If this is unintended, filter your options
or provide a custom key function.
```

### 4. Updated documentation (`types.ts`)

Updated the `key` prop documentation to reflect the new behavior.

## Why This Fix Makes Sense

1. **`value` is the identity** - When an option has `{label, value}`, the `value` is the unique identifier (often a database ID/UUID). The `label` is just for display.
2. **Separation of concerns** - Case-insensitive matching belongs in `searchFunc`/`filterFunc`, not in `key`. The key function is for DOM reconciliation, not user-facing search.
3. **Backwards compatible for most users** - Anyone using simple string options or objects without `value` fields will see the same behavior (minus the problematic lowercase).

## Breaking Change

This is a minor breaking change for anyone relying on case-insensitive key behavior. However, the previous behavior was fundamentally broken as it crashed with case-variant labels that many databases allow.